### PR TITLE
Feature/separate index and header formatting

### DIFF
--- a/pybloqs/block/table_formatters.py
+++ b/pybloqs/block/table_formatters.py
@@ -58,8 +58,12 @@ class TableFormatter(object):
             self.rows = rows
             self.columns = columns
             self.apply_to_header_and_index = apply_to_header_and_index
-            self.apply_to_header = apply_to_header
-            self.apply_to_index = apply_to_index
+            if not self.apply_to_header_and_index:
+                self.apply_to_header = apply_to_header
+                self.apply_to_index = apply_to_index
+            else:
+                self.apply_to_header = False
+                self.apply_to_index = False
             return
 
     def _get_row_and_column_index(self, row_name, column_name, df):
@@ -85,11 +89,12 @@ class TableFormatter(object):
             is_outside_selection = (self.columns is not None and column_name not in self.columns or
                                     self.rows is not None and row_name not in self.rows)
             is_selected_cell = not is_outside_selection
-            if not self.apply_to_header_and_index and not self.apply_to_header and not self.apply_to_index:
-                if row_name == HEADER_ROW_NAME and (self.rows is None or HEADER_ROW_NAME not in self.rows):
-                    is_selected_cell = False
-                if column_name == INDEX_COL_NAME and (self.columns is None or INDEX_COL_NAME not in self.columns):
-                    is_selected_cell = False
+            if not self.apply_to_header_and_index and not self.apply_to_header:
+                    if row_name == HEADER_ROW_NAME and (self.rows is None or HEADER_ROW_NAME not in self.rows):
+                        is_selected_cell = False
+            if not self.apply_to_header_and_index and not self.apply_to_index:
+                    if column_name == INDEX_COL_NAME and (self.columns is None or INDEX_COL_NAME not in self.columns):
+                        is_selected_cell = False
             return is_selected_cell
 
     def _insert_additional_html(self):
@@ -380,8 +385,8 @@ class FmtBold(TableFormatter):
 class FmtAlignCellContents(TableFormatter):
     """Align cell contents. Possible alignment values: left, center, right."""
 
-    def __init__(self, alignment='center', rows=None, columns=None, apply_to_header_and_index=True):
-        super(FmtAlignCellContents, self).__init__(rows, columns, apply_to_header_and_index)
+    def __init__(self, alignment='center', rows=None, columns=None, apply_to_header_and_index=True, apply_to_header=False, apply_to_index=False):
+        super(FmtAlignCellContents, self).__init__(rows, columns, apply_to_header_and_index, apply_to_header, apply_to_index)
         self.alignment = alignment
         return
 

--- a/pybloqs/block/table_formatters.py
+++ b/pybloqs/block/table_formatters.py
@@ -339,8 +339,8 @@ class FmtHighlightText(TableFormatter):
     """Change font formatting to highlight text in cell."""
 
     def __init__(self, bold=True, italic=True, font_color=colors.BLUE, rows=None, columns=None,
-                 apply_to_header_and_index=False):
-        super(FmtHighlightText, self).__init__(rows, columns, apply_to_header_and_index)
+                 apply_to_header_and_index=False, apply_to_header=False, apply_to_index=False):
+        super(FmtHighlightText, self).__init__(rows, columns, apply_to_header_and_index, apply_to_header, apply_to_index)
         self.bold = bold
         self.italic = italic
         self.font_color = font_color

--- a/pybloqs/block/table_formatters.py
+++ b/pybloqs/block/table_formatters.py
@@ -53,11 +53,13 @@ class TableFormatter(object):
         Provides CSS styles to all <th> and <td> HTML tags.
     """
 
-    def __init__(self, rows=None, columns=None, apply_to_header_and_index=True):
+def __init__(self, rows=None, columns=None, apply_to_header_and_index=True, apply_to_header=False, apply_to_index=False):
         """Initialise formatter and specify which rows and columns it is applied to. Default None applies to all."""
         self.rows = rows
         self.columns = columns
         self.apply_to_header_and_index = apply_to_header_and_index
+        self.apply_to_header = apply_to_header
+        self.apply_to_index = apply_to_index
         return
 
     def _get_row_and_column_index(self, row_name, column_name, df):
@@ -73,13 +75,17 @@ class TableFormatter(object):
             column_index = df.columns.get_loc(column_name)
         return Row_col_index(row_index, column_index)
 
-    def _is_selected_cell(self, row_name, column_name):
+def _is_selected_cell(self, row_name, column_name):
         if (row_name == HEADER_ROW_NAME or column_name == INDEX_COL_NAME) and self.apply_to_header_and_index:
+            return True
+        elif (row_name == HEADER_ROW_NAME) and self.apply_to_header:
+            return True
+        elif (column_name == INDEX_COL_NAME) and self.apply_to_index:
             return True
         is_outside_selection = (self.columns is not None and column_name not in self.columns or
                                 self.rows is not None and row_name not in self.rows)
         is_selected_cell = not is_outside_selection
-        if not self.apply_to_header_and_index:
+        if not self.apply_to_header_and_index and not self.apply_to_header and not self.apply_to_index:
             if row_name == HEADER_ROW_NAME and (self.rows is None or HEADER_ROW_NAME not in self.rows):
                 is_selected_cell = False
             if column_name == INDEX_COL_NAME and (self.columns is None or INDEX_COL_NAME not in self.columns):

--- a/pybloqs/block/table_formatters.py
+++ b/pybloqs/block/table_formatters.py
@@ -56,17 +56,17 @@ class TableFormatter(object):
         Provides CSS styles to all <col> HTML tags.
     """
 
-    def __init__(self, rows=None, columns=None, apply_to_header_and_index=True, apply_to_header=False, apply_to_index=False):
-            """Initialise formatter and specify which rows and columns it is applied to. Default None applies to all."""
+    def __init__(self, rows=None, columns=None, apply_to_header_and_index=(True, True)):
+            """Initialise formatter and specify which rows and columns it is applied to. Default None applies to all.
+            boolean or 2-tuple of booleans can be supplied to apply_to_header_and_index.
+            """
             self.rows = rows
             self.columns = columns
             self.apply_to_header_and_index = apply_to_header_and_index
-            if not self.apply_to_header_and_index:
-                self.apply_to_header = apply_to_header
-                self.apply_to_index = apply_to_index
-            else:
-                self.apply_to_header = False
-                self.apply_to_index = False
+            if isinstance(apply_to_header_and_index, bool):
+                apply_to_header_and_index = (apply_to_header_and_index, apply_to_header_and_index)
+            self.apply_to_header = apply_to_header_and_index[0]
+            self.apply_to_index = apply_to_header_and_index[1]
             return
 
     def _get_row_and_column_index(self, row_name, column_name, df):
@@ -83,19 +83,17 @@ class TableFormatter(object):
         return Row_col_index(row_index, column_index)
 
     def _is_selected_cell(self, row_name, column_name):
-            if (row_name == HEADER_ROW_NAME or column_name == INDEX_COL_NAME) and self.apply_to_header_and_index:
-                return True
-            elif (row_name == HEADER_ROW_NAME) and self.apply_to_header:
+            if (row_name == HEADER_ROW_NAME) and self.apply_to_header:
                 return True
             elif (column_name == INDEX_COL_NAME) and (row_name != HEADER_ROW_NAME) and self.apply_to_index:
                 return True
             is_outside_selection = (self.columns is not None and column_name not in self.columns or
                                     self.rows is not None and row_name not in self.rows)
             is_selected_cell = not is_outside_selection
-            if not self.apply_to_header_and_index and not self.apply_to_header:
+            if not self.apply_to_header:
                     if row_name == HEADER_ROW_NAME and (self.rows is None or HEADER_ROW_NAME not in self.rows):
                         is_selected_cell = False
-            if not self.apply_to_header_and_index and not self.apply_to_index:
+            if not self.apply_to_index:
                     if (column_name == INDEX_COL_NAME) and (row_name != HEADER_ROW_NAME) and (self.columns is None or INDEX_COL_NAME not in self.columns):
                         is_selected_cell = False
             return is_selected_cell
@@ -350,8 +348,8 @@ class FmtHighlightText(TableFormatter):
     """Change font formatting to highlight text in cell."""
 
     def __init__(self, bold=True, italic=True, font_color=colors.BLUE, rows=None, columns=None,
-                 apply_to_header_and_index=False, apply_to_header=False, apply_to_index=False):
-        super(FmtHighlightText, self).__init__(rows, columns, apply_to_header_and_index, apply_to_header, apply_to_index)
+                 apply_to_header_and_index=False):
+        super(FmtHighlightText, self).__init__(rows, columns, apply_to_header_and_index)
         self.bold = bold
         self.italic = italic
         self.font_color = font_color
@@ -372,8 +370,8 @@ class FmtHighlightText(TableFormatter):
 class FmtHighlightBackground(TableFormatter):
     """Set background color of selected cells"""
 
-    def __init__(self, color=colors.RED, rows=None, columns=None, apply_to_header_and_index=False, apply_to_header=False, apply_to_index=False):
-        super(FmtHighlightBackground, self).__init__(rows, columns, apply_to_header_and_index, apply_to_header, apply_to_index)
+    def __init__(self, color=colors.RED, rows=None, columns=None, apply_to_header_and_index=False):
+        super(FmtHighlightBackground, self).__init__(rows, columns, apply_to_header_and_index)
         self.color = color
         return
 
@@ -396,8 +394,8 @@ class FmtBold(TableFormatter):
 class FmtAlignCellContents(TableFormatter):
     """Align cell contents. Possible alignment values: left, center, right."""
 
-    def __init__(self, alignment='center', rows=None, columns=None, apply_to_header_and_index=True, apply_to_header=False, apply_to_index=False):
-        super(FmtAlignCellContents, self).__init__(rows, columns, apply_to_header_and_index, apply_to_header, apply_to_index)
+    def __init__(self, alignment='center', rows=None, columns=None, apply_to_header_and_index=True):
+        super(FmtAlignCellContents, self).__init__(rows, columns, apply_to_header_and_index)
         self.alignment = alignment
         return
 

--- a/pybloqs/block/table_formatters.py
+++ b/pybloqs/block/table_formatters.py
@@ -356,8 +356,8 @@ class FmtHighlightText(TableFormatter):
 class FmtHighlightBackground(TableFormatter):
     """Set background color of selected cells"""
 
-    def __init__(self, color=colors.RED, rows=None, columns=None, apply_to_header_and_index=False):
-        super(FmtHighlightBackground, self).__init__(rows, columns, apply_to_header_and_index)
+    def __init__(self, color=colors.RED, rows=None, columns=None, apply_to_header_and_index=False, apply_to_header=False, apply_to_index=False):
+        super(FmtHighlightBackground, self).__init__(rows, columns, apply_to_header_and_index, apply_to_header, apply_to_index)
         self.color = color
         return
 

--- a/pybloqs/block/table_formatters.py
+++ b/pybloqs/block/table_formatters.py
@@ -53,14 +53,14 @@ class TableFormatter(object):
         Provides CSS styles to all <th> and <td> HTML tags.
     """
 
-def __init__(self, rows=None, columns=None, apply_to_header_and_index=True, apply_to_header=False, apply_to_index=False):
-        """Initialise formatter and specify which rows and columns it is applied to. Default None applies to all."""
-        self.rows = rows
-        self.columns = columns
-        self.apply_to_header_and_index = apply_to_header_and_index
-        self.apply_to_header = apply_to_header
-        self.apply_to_index = apply_to_index
-        return
+    def __init__(self, rows=None, columns=None, apply_to_header_and_index=True, apply_to_header=False, apply_to_index=False):
+            """Initialise formatter and specify which rows and columns it is applied to. Default None applies to all."""
+            self.rows = rows
+            self.columns = columns
+            self.apply_to_header_and_index = apply_to_header_and_index
+            self.apply_to_header = apply_to_header
+            self.apply_to_index = apply_to_index
+            return
 
     def _get_row_and_column_index(self, row_name, column_name, df):
         "Return row index and column index of given row_name and column name. Requires unique index and column names."
@@ -75,22 +75,22 @@ def __init__(self, rows=None, columns=None, apply_to_header_and_index=True, appl
             column_index = df.columns.get_loc(column_name)
         return Row_col_index(row_index, column_index)
 
-def _is_selected_cell(self, row_name, column_name):
-        if (row_name == HEADER_ROW_NAME or column_name == INDEX_COL_NAME) and self.apply_to_header_and_index:
-            return True
-        elif (row_name == HEADER_ROW_NAME) and self.apply_to_header:
-            return True
-        elif (column_name == INDEX_COL_NAME) and self.apply_to_index:
-            return True
-        is_outside_selection = (self.columns is not None and column_name not in self.columns or
-                                self.rows is not None and row_name not in self.rows)
-        is_selected_cell = not is_outside_selection
-        if not self.apply_to_header_and_index and not self.apply_to_header and not self.apply_to_index:
-            if row_name == HEADER_ROW_NAME and (self.rows is None or HEADER_ROW_NAME not in self.rows):
-                is_selected_cell = False
-            if column_name == INDEX_COL_NAME and (self.columns is None or INDEX_COL_NAME not in self.columns):
-                is_selected_cell = False
-        return is_selected_cell
+    def _is_selected_cell(self, row_name, column_name):
+            if (row_name == HEADER_ROW_NAME or column_name == INDEX_COL_NAME) and self.apply_to_header_and_index:
+                return True
+            elif (row_name == HEADER_ROW_NAME) and self.apply_to_header:
+                return True
+            elif (column_name == INDEX_COL_NAME) and self.apply_to_index:
+                return True
+            is_outside_selection = (self.columns is not None and column_name not in self.columns or
+                                    self.rows is not None and row_name not in self.rows)
+            is_selected_cell = not is_outside_selection
+            if not self.apply_to_header_and_index and not self.apply_to_header and not self.apply_to_index:
+                if row_name == HEADER_ROW_NAME and (self.rows is None or HEADER_ROW_NAME not in self.rows):
+                    is_selected_cell = False
+                if column_name == INDEX_COL_NAME and (self.columns is None or INDEX_COL_NAME not in self.columns):
+                    is_selected_cell = False
+            return is_selected_cell
 
     def _insert_additional_html(self):
         """Insert HTML string before table."""

--- a/pybloqs/block/table_formatters.py
+++ b/pybloqs/block/table_formatters.py
@@ -393,8 +393,8 @@ class FmtHeader(TableFormatter):
     """Set various header formatting. Fixes table width."""
 
     def __init__(self, fixed_width='100%', index_width=None, column_width=None, rotate_deg=0,
-                 top_padding=None, no_wrap=True, columns=None):
-        super(FmtHeader, self).__init__(None, None)
+                 top_padding=None, no_wrap=True, columns=None, color=None):
+        super(FmtHeader, self).__init__(None, None)  # , apply_to_header=True
         self.fixed_width = fixed_width
         self.index_width = index_width
         self.column_width = column_width
@@ -402,6 +402,7 @@ class FmtHeader(TableFormatter):
         self.top_padding = top_padding
         self.no_wrap = no_wrap
         self.columns = columns
+        self.color = color
         return
 
     def _create_table_level_css(self):
@@ -429,6 +430,8 @@ class FmtHeader(TableFormatter):
                 css_substrings.append(CSS_WIDTH + self.index_width)
             elif self.column_width is not None:
                 css_substrings.append('width:' + self.column_width)
+            if self.color is not None:
+                css_substrings.append(CSS_BACKGROUND_COLOR + colors.css_color(self.color))
             return "; ".join(css_substrings)
         else:
             return None

--- a/pybloqs/block/table_formatters.py
+++ b/pybloqs/block/table_formatters.py
@@ -399,7 +399,7 @@ class FmtHeader(TableFormatter):
 
     def __init__(self, fixed_width='100%', index_width=None, column_width=None, rotate_deg=0,
                  top_padding=None, no_wrap=True, columns=None, color=None):
-        super(FmtHeader, self).__init__(None, None)  # , apply_to_header=True
+        super(FmtHeader, self).__init__(None, None)
         self.fixed_width = fixed_width
         self.index_width = index_width
         self.column_width = column_width

--- a/pybloqs/block/table_formatters.py
+++ b/pybloqs/block/table_formatters.py
@@ -84,7 +84,7 @@ class TableFormatter(object):
                 return True
             elif (row_name == HEADER_ROW_NAME) and self.apply_to_header:
                 return True
-            elif (column_name == INDEX_COL_NAME) and self.apply_to_index:
+            elif (column_name == INDEX_COL_NAME) and (row_name != HEADER_ROW_NAME) and self.apply_to_index:
                 return True
             is_outside_selection = (self.columns is not None and column_name not in self.columns or
                                     self.rows is not None and row_name not in self.rows)
@@ -93,7 +93,7 @@ class TableFormatter(object):
                     if row_name == HEADER_ROW_NAME and (self.rows is None or HEADER_ROW_NAME not in self.rows):
                         is_selected_cell = False
             if not self.apply_to_header_and_index and not self.apply_to_index:
-                    if column_name == INDEX_COL_NAME and (self.columns is None or INDEX_COL_NAME not in self.columns):
+                    if (column_name == INDEX_COL_NAME) and (row_name != HEADER_ROW_NAME) and (self.columns is None or INDEX_COL_NAME not in self.columns):
                         is_selected_cell = False
             return is_selected_cell
 

--- a/tests/unit/block/test_table_formatters.py
+++ b/tests/unit/block/test_table_formatters.py
@@ -87,28 +87,28 @@ def test_TableFormatter__is_selected_cell():
     assert tf._is_selected_cell(pbtf.HEADER_ROW_NAME, pbtf.INDEX_COL_NAME) == True
     
     # Check case 5)
-    tf = pbtf.TableFormatter(rows=None, columns=None, apply_to_header_and_index=False, apply_to_header=True, apply_to_index=True)
+    tf = pbtf.TableFormatter(rows=None, columns=None, apply_to_header_and_index=(True, True))
     assert tf._is_selected_cell('a', 'aa') == True
     assert tf._is_selected_cell('a', pbtf.INDEX_COL_NAME) == True
     assert tf._is_selected_cell(pbtf.HEADER_ROW_NAME, 'aa') == True
     assert tf._is_selected_cell(pbtf.HEADER_ROW_NAME, pbtf.INDEX_COL_NAME) == True
     
     # Check case 6)
-    tf = pbtf.TableFormatter(rows=None, columns=None, apply_to_header_and_index=False, apply_to_header=False, apply_to_index=True)
+    tf = pbtf.TableFormatter(rows=None, columns=None, apply_to_header_and_index=(False, True))
     assert tf._is_selected_cell('a', 'aa') == True
     assert tf._is_selected_cell('a', pbtf.INDEX_COL_NAME) == True
     assert tf._is_selected_cell(pbtf.HEADER_ROW_NAME, 'aa') == False
     assert tf._is_selected_cell(pbtf.HEADER_ROW_NAME, pbtf.INDEX_COL_NAME) == False
     
     # Check case 7)
-    tf = pbtf.TableFormatter(rows=None, columns=None, apply_to_header_and_index=False, apply_to_header=True, apply_to_index=False)
+    tf = pbtf.TableFormatter(rows=None, columns=None, apply_to_header_and_index=(True, False))
     assert tf._is_selected_cell('a', 'aa') == True
     assert tf._is_selected_cell('a', pbtf.INDEX_COL_NAME) == False
     assert tf._is_selected_cell(pbtf.HEADER_ROW_NAME, 'aa') == True
     assert tf._is_selected_cell(pbtf.HEADER_ROW_NAME, pbtf.INDEX_COL_NAME) == True
     
     # Check case 8)
-    tf = pbtf.TableFormatter(rows=['b'], columns=['bb'], apply_to_header_and_index=False, apply_to_header=False, apply_to_index=True)
+    tf = pbtf.TableFormatter(rows=['b'], columns=['bb'], apply_to_header_and_index=(False, True))
     assert tf._is_selected_cell('b', 'bb') == True
     assert tf._is_selected_cell('b', 'aa') == False
     assert tf._is_selected_cell('a', 'bb') == False
@@ -119,7 +119,7 @@ def test_TableFormatter__is_selected_cell():
     assert tf._is_selected_cell(pbtf.HEADER_ROW_NAME, pbtf.INDEX_COL_NAME) == False
     
     # Check case 9)
-    tf = pbtf.TableFormatter(rows=['b'], columns=['bb'], apply_to_header_and_index=False, apply_to_header=True, apply_to_index=False)
+    tf = pbtf.TableFormatter(rows=['b'], columns=['bb'], apply_to_header_and_index=(True, False))
     assert tf._is_selected_cell('b', 'bb') == True
     assert tf._is_selected_cell('b', 'aa') == False
     assert tf._is_selected_cell('a', 'bb') == False
@@ -385,6 +385,12 @@ def test_FmtBold():
 
 
 @pytest.mark.parametrize('apply_to_header_and_index', [True, False])
+def test_test_FmtBold_headerandindex(apply_to_header_and_index):
+    fmt = pbtf.FmtBold(apply_to_header_and_index=apply_to_header_and_index)
+    assert fmt.apply_to_header_and_index == apply_to_header_and_index
+
+
+@pytest.mark.parametrize('apply_to_header_and_index', [(True, False), (False, True)])
 def test_test_FmtBold_headerandindex(apply_to_header_and_index):
     fmt = pbtf.FmtBold(apply_to_header_and_index=apply_to_header_and_index)
     assert fmt.apply_to_header_and_index == apply_to_header_and_index

--- a/tests/unit/block/test_table_formatters.py
+++ b/tests/unit/block/test_table_formatters.py
@@ -36,6 +36,16 @@ def test_TableFormatter__is_selected_cell():
     # 2) rows, columns is None, apply_to_header_and_index is False => Work on data cells
     # 3) rows, columns is not None, apply_to_header_and_index is False => Work on selected cells, including header,index
     # 4) rows, columns is not None, apply_to_header_and_index is True => Work on selected cells; header,index always
+    # 5) rows, columns is None, apply_to_header_and_index is False, apply_to_header is True, apply_to_index is True 
+    # => Work on all cells (same as case 1))
+    # 6) rows, columns is None, apply_to_header_and_index is False, apply_to_header is False, apply_to_index is True 
+    # => Work on all cells excluding header (note header includes top left corner)
+    # 7) rows, columns is None, apply_to_header_and_index is False, apply_to_header is True, apply_to_index is False 
+    # => Work on all cells excluding index (note index does not include top left corner)
+    # 8) rows, columns is not None, apply_to_header_and_index is False, apply_to_header is False, apply_to_index is True 
+    # => Work on selected cells; index always (note index does not include top left corner)
+    # 9) rows, columns is not None, apply_to_header_and_index is False, apply_to_header is True, apply_to_index is False 
+    # => Work on selected cells; header always (note header includes top left corner)
 
     # Check case 1)
     tf = pbtf.TableFormatter(rows=None, columns=None)
@@ -51,7 +61,7 @@ def test_TableFormatter__is_selected_cell():
     assert tf._is_selected_cell(pbtf.HEADER_ROW_NAME, 'aa') == False
     assert tf._is_selected_cell(pbtf.HEADER_ROW_NAME, pbtf.INDEX_COL_NAME) == False
 
-    # Check case3)
+    # Check case 3)
     row_names = ['a', pbtf.HEADER_ROW_NAME]
     column_names = ['aa', pbtf.INDEX_COL_NAME]
     tf = pbtf.TableFormatter(rows=row_names, columns=column_names, apply_to_header_and_index=False)
@@ -65,13 +75,56 @@ def test_TableFormatter__is_selected_cell():
     assert tf._is_selected_cell(pbtf.HEADER_ROW_NAME, pbtf.INDEX_COL_NAME) == True
     assert tf._is_selected_cell('a', 'cc') == False
 
-    # Check case4)
+    # Check case 4)
     tf = pbtf.TableFormatter(rows=['b'], columns=['bb'], apply_to_header_and_index=True)
     assert tf._is_selected_cell('b', 'bb') == True
     assert tf._is_selected_cell('b', 'aa') == False
     assert tf._is_selected_cell('a', 'bb') == False
     assert tf._is_selected_cell('a', pbtf.INDEX_COL_NAME) == True
     assert tf._is_selected_cell('b', pbtf.INDEX_COL_NAME) == True
+    assert tf._is_selected_cell(pbtf.HEADER_ROW_NAME, 'aa') == True
+    assert tf._is_selected_cell(pbtf.HEADER_ROW_NAME, 'bb') == True
+    assert tf._is_selected_cell(pbtf.HEADER_ROW_NAME, pbtf.INDEX_COL_NAME) == True
+    
+    # Check case 5)
+    tf = pbtf.TableFormatter(rows=None, columns=None, apply_to_header_and_index=False, apply_to_header=True, apply_to_index=True)
+    assert tf._is_selected_cell('a', 'aa') == True
+    assert tf._is_selected_cell('a', pbtf.INDEX_COL_NAME) == True
+    assert tf._is_selected_cell(pbtf.HEADER_ROW_NAME, 'aa') == True
+    assert tf._is_selected_cell(pbtf.HEADER_ROW_NAME, pbtf.INDEX_COL_NAME) == True
+    
+    # Check case 6)
+    tf = pbtf.TableFormatter(rows=None, columns=None, apply_to_header_and_index=False, apply_to_header=False, apply_to_index=True)
+    assert tf._is_selected_cell('a', 'aa') == True
+    assert tf._is_selected_cell('a', pbtf.INDEX_COL_NAME) == True
+    assert tf._is_selected_cell(pbtf.HEADER_ROW_NAME, 'aa') == False
+    assert tf._is_selected_cell(pbtf.HEADER_ROW_NAME, pbtf.INDEX_COL_NAME) == False
+    
+    # Check case 7)
+    tf = pbtf.TableFormatter(rows=None, columns=None, apply_to_header_and_index=False, apply_to_header=True, apply_to_index=False)
+    assert tf._is_selected_cell('a', 'aa') == True
+    assert tf._is_selected_cell('a', pbtf.INDEX_COL_NAME) == False
+    assert tf._is_selected_cell(pbtf.HEADER_ROW_NAME, 'aa') == True
+    assert tf._is_selected_cell(pbtf.HEADER_ROW_NAME, pbtf.INDEX_COL_NAME) == True
+    
+    # Check case 8)
+    tf = pbtf.TableFormatter(rows=['b'], columns=['bb'], apply_to_header_and_index=False, apply_to_header=False, apply_to_index=True)
+    assert tf._is_selected_cell('b', 'bb') == True
+    assert tf._is_selected_cell('b', 'aa') == False
+    assert tf._is_selected_cell('a', 'bb') == False
+    assert tf._is_selected_cell('a', pbtf.INDEX_COL_NAME) == True
+    assert tf._is_selected_cell('b', pbtf.INDEX_COL_NAME) == True
+    assert tf._is_selected_cell(pbtf.HEADER_ROW_NAME, 'aa') == False
+    assert tf._is_selected_cell(pbtf.HEADER_ROW_NAME, 'bb') == False
+    assert tf._is_selected_cell(pbtf.HEADER_ROW_NAME, pbtf.INDEX_COL_NAME) == False
+    
+    # Check case 9)
+    tf = pbtf.TableFormatter(rows=['b'], columns=['bb'], apply_to_header_and_index=False, apply_to_header=True, apply_to_index=False)
+    assert tf._is_selected_cell('b', 'bb') == True
+    assert tf._is_selected_cell('b', 'aa') == False
+    assert tf._is_selected_cell('a', 'bb') == False
+    assert tf._is_selected_cell('a', pbtf.INDEX_COL_NAME) == False
+    assert tf._is_selected_cell('b', pbtf.INDEX_COL_NAME) == False
     assert tf._is_selected_cell(pbtf.HEADER_ROW_NAME, 'aa') == True
     assert tf._is_selected_cell(pbtf.HEADER_ROW_NAME, 'bb') == True
     assert tf._is_selected_cell(pbtf.HEADER_ROW_NAME, pbtf.INDEX_COL_NAME) == True


### PR DESCRIPTION
- Added functionality in table_formatters.py to highlight index and header individually with apply_to_header and apply_to_index arguments to TableFormatter class constructor, used by table_formatters.FmtHighlightBackground(). 
- Added necessary logic in _is_selected_cell().
- apply_to_header and apply_to_index arguments are False by default and only used if apply_to_header_and_index is False (setting both to True should have same effect as setting apply_to_header_and_index=True).
- Added tests in test_table_formatters.py to test new functionality to select index and headers individually using these new arguments.
- Added ability to color header in table_formatters.FmtHeader().
