### PR TITLE
Various fixes for MultiIndex headers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ defaults: &defaults
         - v1-dep-master-
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
-    - run: wget https://downloads.wkhtmltopdf.org/0.12/0.12.4/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz
+    - run: wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz
     - run: tar Jxvf wkhtmltox-0.12.4_linux-generic-amd64.tar.xz
     - run: sudo apt-get install poppler-utils
     - run: sudo apt-get install pandoc

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,5 +1,5 @@
 sphinx==1.6.7
-nbsphinx
+nbsphinx==0.4.3
 matplotlib
 ipython[notebook]
 pyyaml

--- a/pybloqs/block/table.py
+++ b/pybloqs/block/table.py
@@ -4,7 +4,7 @@ from jinja2 import Environment, PackageLoader
 
 from pybloqs.block.base import BaseBlock
 from pybloqs.block.convenience import add_block_types
-from pybloqs.block.table_formatters import DEFAULT_FORMATTERS, DEFAULT_DECIMALS_FORMATTER, ORG_ROW_NAMES
+from pybloqs.block.table_formatters import DEFAULT_FORMATTERS, DEFAULT_DECIMALS_FORMATTER, ORG_ROW_NAMES, INDEX_COL_NAME
 from pybloqs.html import parse
 
 import pandas as pd
@@ -18,10 +18,12 @@ _table_tmpl = _jinja_env.get_template('table.html')
 
 class HTMLJinjaTableBlock(BaseBlock):
     FormatterData = namedtuple('FormatterData', ['cell', 'row_name', 'column_name', 'df'])
+    HeaderCell = namedtuple('HeaderCell', ['cell', 'column_names', 'colspan', 'rowspan'])
 
-    def __init__(self, df, formatters=None, use_default_formatters=True, **kwargs):
-        """Create table from Jinga framework. Apply formatters to customise table formatting. 
-
+    def __init__(
+            self, df, formatters=None, use_default_formatters=True, merge_vertical=False, **kwargs
+    ):
+        """Create table from Jinja framework. Apply formatters to customise table formatting.
 
         Parameters()
         ----------
@@ -45,7 +47,7 @@ class HTMLJinjaTableBlock(BaseBlock):
                 continue
         self.df = df
         self.n_header_rows = len(df.columns.names)
-        return
+        self.merge_vertical = merge_vertical
 
     def modify_cell_content(self, cell, row_name, column_name):
         if ORG_ROW_NAMES in self.df.columns and self.row_index > 0:
@@ -100,6 +102,14 @@ class HTMLJinjaTableBlock(BaseBlock):
         data = pd.Series(row, name=row_name)
         return self._aggregate_css_formatters('create_row_level_css', fmt_args=[data])
 
+    def create_column_level_css(self, column_name):
+        if column_name == INDEX_COL_NAME:
+            series = self.df.index
+        else:
+            series = self.df[column_name]
+        data = self.FormatterData(None, None, column_name, series)
+        return self._aggregate_css_formatters('create_column_level_css', fmt_args=[data])
+
     def create_cell_level_css(self, cell, row_name, column_name):
         if ORG_ROW_NAMES in self.df.columns and self.row_index >= 0:
             row_name = self.df[ORG_ROW_NAMES].iloc[self.row_index]
@@ -107,21 +117,54 @@ class HTMLJinjaTableBlock(BaseBlock):
         return self._aggregate_css_formatters('create_cell_level_css', fmt_args=[data])
 
     def _get_header_iterable(self):
-        """Reformats all but the last header rows."""
+        """Reformats all but the last header rows.
+
+        Returns a list (rows) of lists (columns) of named tuples (cells) containing:
+        * cell: str -- contents of the header cell
+        * columns: list[object] -- list of columns covered by this cell (typically
+          a single value but may be more if a multiindex label has been merged)
+        * colspan: int -- width, in columns, of the cell.
+        * rowspan: int -- height, in rows, of the cell.
+        """
         df_clean = self.df.loc[:, self.df.columns.get_level_values(0) != ORG_ROW_NAMES]
+
         if isinstance(df_clean.columns, pd.MultiIndex):
-            transpose_tuples = list(zip(*df_clean.columns.tolist()))
-            header_values = []
-            for i, t in enumerate(transpose_tuples):
-                if i < len(transpose_tuples) - 1:
-                    # Not the last column, aggregate repeated items, e.g. [['aa', 'aa', 'aa'], ['bb', 'bb', 'bb']]
-                    header_values.append([list(g) for _, g in itertools.groupby(t)])
-                else:
-                    # For the last column keep all elements in single list, e.g. ['a', 'b', 'c', 'a', 'b', 'c']
-                    header_values.append(list(t))
+            transpose_tuples = list(zip(*df_clean.columns.tolist()))[:-1]
+            header_values = [[] for _ in transpose_tuples]
+
+            def traverse_headers(row, col_start, col_end):
+                if row >= len(transpose_tuples):
+                    return
+
+                groups = itertools.groupby(transpose_tuples[row][col_start:col_end])
+                col = col_start
+                for label, group in groups:
+                    group = tuple(group)
+                    colspan = len(group)
+                    rowspan = 1
+
+                    if self.merge_vertical:
+                        for child_row in range(row + 1, len(transpose_tuples)):
+                            if transpose_tuples[child_row][col:col+colspan] != group:
+                                break
+                            rowspan += 1
+
+                    header_values[row].append(self.HeaderCell(
+                        group[0],
+                        multiindex_to_tuples(df_clean.columns[col:col + colspan]),
+                        colspan,
+                        rowspan
+                    ))
+                    traverse_headers(row + rowspan, col, col + colspan)
+                    col += colspan
+
+            traverse_headers(0, 0, len(df_clean.columns))
+
+            # For the last column keep all elements in single list, e.g. ['a', 'b', 'c', 'a', 'b', 'c']
+            header_values.append([self.HeaderCell(col[-1], [col], 1, 1) for col in df_clean.columns])
             return header_values
         else:
-            return [df_clean.columns.tolist()]
+            return [[self.HeaderCell(col, [col], 1, 1) for col in df_clean.columns]]
 
     def _write_contents(self, container, actual_cfg, *args, **kwargs):
         # table boilerplate
@@ -131,6 +174,7 @@ class HTMLJinjaTableBlock(BaseBlock):
                  'create_thead_level_css': self.create_thead_level_css,
                  'create_table_level_css': self.create_table_level_css,
                  'create_table_level_css_class': self.create_table_level_css_class,
+                 'create_column_level_css': self.create_column_level_css,
                  'create_row_level_css': self.create_row_level_css,
                  'create_cell_level_css': self.create_cell_level_css,
                  'modify_cell_content': self.modify_cell_content}
@@ -140,6 +184,10 @@ class HTMLJinjaTableBlock(BaseBlock):
         table = soup.find("table")
         container.append(table)
         return
+
+
+def multiindex_to_tuples(index):
+    return [tuple(col) for col in index]
 
 
 add_block_types(pd.DataFrame, HTMLJinjaTableBlock)

--- a/pybloqs/block/table.py
+++ b/pybloqs/block/table.py
@@ -102,11 +102,7 @@ class HTMLJinjaTableBlock(BaseBlock):
         data = pd.Series(row, name=row_name)
         return self._aggregate_css_formatters('create_row_level_css', fmt_args=[data])
 
-    def create_column_level_css(self, column_name):
-        if column_name == INDEX_COL_NAME:
-            series = self.df.index
-        else:
-            series = self.df[column_name]
+    def create_column_level_css(self, column_name, series):
         data = self.FormatterData(None, None, column_name, series)
         return self._aggregate_css_formatters('create_column_level_css', fmt_args=[data])
 

--- a/pybloqs/block/table_formatters.py
+++ b/pybloqs/block/table_formatters.py
@@ -51,6 +51,9 @@ class TableFormatter(object):
 
     _create_cell_level_css()
         Provides CSS styles to all <th> and <td> HTML tags.
+
+    _create_column_level_css()
+        Provides CSS styles to all <col> HTML tags.
     """
 
     def __init__(self, rows=None, columns=None, apply_to_header_and_index=True):
@@ -110,6 +113,10 @@ class TableFormatter(object):
         """Formatting on CSS level, e.g. colors, borders, etc. on table row level"""
         raise NotImplementedError('format_row_css')
 
+    def _create_column_level_css(self, data):
+        """Formatting on CSS level, e.g. widths """
+        raise NotImplementedError('format_column_css')
+
     def _create_cell_level_css(self, data):
         """Formatting on CSS level, e.g. colors, borders, etc. """
         raise NotImplementedError('format_cell_css')
@@ -144,6 +151,10 @@ class TableFormatter(object):
     def create_row_level_css(self, data):
         """Formatting on CSS level, e.g. colors, borders, etc. """
         return self._create_row_level_css(data)
+
+    def create_column_level_css(self, data):
+        """Formatting on CSS level, e.g. widths """
+        return self._create_column_level_css(data)
 
     def create_cell_level_css(self, data):
         """Formatting on CSS level, e.g. colors, borders, etc. """
@@ -407,6 +418,15 @@ class FmtHeader(TableFormatter):
             css_substrings.append(CSS_WIDTH + self.fixed_width)
             css_substrings.append('table-layout:fixed;')
         return "; ".join(css_substrings)
+
+    def _create_column_level_css(self, data):
+        if self.columns is None or data.column_name in self.columns:
+            css_substrings = []
+            if data.column_name == INDEX_COL_NAME and self.index_width is not None:
+                css_substrings.append(CSS_WIDTH + self.index_width)
+            elif self.column_width is not None:
+                css_substrings.append(CSS_WIDTH + self.column_width)
+            return "; ".join(css_substrings)
 
     def _create_cell_level_css(self, data):
         """Set a lot of css tags to rotate the text in the table header."""

--- a/pybloqs/jinja/table.html
+++ b/pybloqs/jinja/table.html
@@ -1,32 +1,33 @@
 {{insert_additional_html()}}
 <table id="blox_table_id" border="0" cellpadding="1" cellspacing="0" {{create_table_level_css()}} {{create_table_level_css_class()}}>
-	<thead {{create_thead_level_css()}}>
-       {% for header_index, header_row in enumerate(header_iterable)  %}
-           <tr {{create_row_level_css(__JINJA_HEADER__, header_row)}}>
-                {% if header_index == len(header_iterable) -1 %}
-	                <th {{create_cell_level_css(cell, "__JINJA_HEADER__", "__JINJA_INDEX__")}}>
+    <colgroup>
+        <col {{create_column_level_css("__JINJA_INDEX__")}}/>
+        {% for col_name in df.columns %}
+            <col {{create_column_level_css(col_name)}}/>
+        {% endfor %}
+    </colgroup>
+    <thead {{create_thead_level_css()}}>
+        {% for header_index, header_row in enumerate(header_iterable)  %}
+            <tr {{create_row_level_css(__JINJA_HEADER__, header_row)}}>
+                {% if header_index == len(header_iterable) - 1 %}
+                    <th {{create_cell_level_css(df.index.name, "__JINJA_HEADER__", "__JINJA_INDEX__")}}>
                         {% if df.index.name is not none%}
-    	                    {{modify_cell_content(df.index.name,  "__JINJA_HEADER__", "__JINJA_INDEX__")}}
+                            {{modify_cell_content(df.index.name,  "__JINJA_HEADER__", "__JINJA_INDEX__")}}
                         {% endif%}
                     </th>
-               {% else %}
-                    <th {{create_cell_level_css(cell, "__JINJA_HEADER__", "__JINJA_INDEX__")}}></th>
-               {% endif %}
-               {% for column_idx, item in enumerate(header_row) %}
-	                {% if header_index == len(header_iterable) -1 %}
-	                    <th {{create_cell_level_css(cell, "__JINJA_HEADER__",df.columns.tolist()[column_idx])}}>
-	                        {{modify_cell_content(item,  "__JINJA_HEADER__", df.columns.tolist()[column_idx])}}
-	                    </th>
-	                {% else %}
-                         <th colspan={{len(item)}} {{create_cell_level_css(cell, "__JINJA_HEADER__",df.columns.tolist()[column_idx])}}>
-                             {{modify_cell_content(item[0],  "__JINJA_HEADER__", df.columns.tolist()[column_idx])}}
-                         </th>
-                    {% endif %}
-               {% endfor %}
-	       </tr>
+                {% else %}
+                    <th {{create_cell_level_css(none, "__JINJA_HEADER__", "__JINJA_INDEX__")}}></th>
+                {% endif %}
+                {% for column_idx, (item, columns, colspan, rowspan) in enumerate(header_row) %}
+                    <th {{create_cell_level_css(item, "__JINJA_HEADER__", columns[0])}}
+                        colspan="{{colspan}}" rowspan="{{rowspan}}">
+                        {{modify_cell_content(item, "__JINJA_HEADER__", columns[0])}}
+                    </th>
+                {% endfor %}
+            </tr>
         {% endfor %}
-	</thead>
-	<tbody>
+    </thead>
+    <tbody>
         {% for row_name, row in df.loc[slice(None), df.columns.get_level_values(0) != '__MULTIINDEX_ORG_ROW_NAMES__'].reset_index().T.iteritems() %}
         <tr {{create_row_level_css(row_name, row)}}>
             <td {{create_cell_level_css(row.iloc[0], row.iloc[0], "__JINJA_INDEX__")}}>

--- a/pybloqs/jinja/table.html
+++ b/pybloqs/jinja/table.html
@@ -1,9 +1,9 @@
 {{insert_additional_html()}}
 <table id="blox_table_id" border="0" cellpadding="1" cellspacing="0" {{create_table_level_css()}} {{create_table_level_css_class()}}>
     <colgroup>
-        <col {{create_column_level_css("__JINJA_INDEX__")}}/>
-        {% for col_name in df.columns %}
-            <col {{create_column_level_css(col_name)}}/>
+        <col {{create_column_level_css("__JINJA_INDEX__", df.index)}}/>
+        {% for i, col_name in enumerate(df.columns) %}
+            <col {{create_column_level_css(col_name, df.iloc[slice(None), i])}}/>
         {% endfor %}
     </colgroup>
     <thead {{create_thead_level_css()}}>

--- a/tests/unit/block/test_table.py
+++ b/tests/unit/block/test_table.py
@@ -134,8 +134,28 @@ def test__get_header_iterable_multiindex():
     df = df.groupby(['grouping', 'index']).sum().unstack()
     t = abt.HTMLJinjaTableBlock(df)
     result = t._get_header_iterable()
-    expected = [[['aa', 'aa', 'aa'], ['bb', 'bb', 'bb'], ['cc', 'cc', 'cc'], ['aa', 'aa', 'aa']],
-                ['a', 'b', 'c', 'a', 'b', 'c', 'a', 'b', 'c', 'a', 'b', 'c']]
+    expected = [
+        [
+            abt.HTMLJinjaTableBlock.HeaderCell('aa', [('aa', 'a'), ('aa', 'b'), ('aa', 'c')], 3, 1),
+            abt.HTMLJinjaTableBlock.HeaderCell('bb', [('bb', 'a'), ('bb', 'b'), ('bb', 'c')], 3, 1),
+            abt.HTMLJinjaTableBlock.HeaderCell('cc', [('cc', 'a'), ('cc', 'b'), ('cc', 'c')], 3, 1),
+            abt.HTMLJinjaTableBlock.HeaderCell('aa', [('aa', 'a'), ('aa', 'b'), ('aa', 'c')], 3, 1),
+        ],
+        [
+            abt.HTMLJinjaTableBlock.HeaderCell('a', [('aa', 'a')], 1, 1),
+            abt.HTMLJinjaTableBlock.HeaderCell('b', [('aa', 'b')], 1, 1),
+            abt.HTMLJinjaTableBlock.HeaderCell('c', [('aa', 'c')], 1, 1),
+            abt.HTMLJinjaTableBlock.HeaderCell('a', [('bb', 'a')], 1, 1),
+            abt.HTMLJinjaTableBlock.HeaderCell('b', [('bb', 'b')], 1, 1),
+            abt.HTMLJinjaTableBlock.HeaderCell('c', [('bb', 'c')], 1, 1),
+            abt.HTMLJinjaTableBlock.HeaderCell('a', [('cc', 'a')], 1, 1),
+            abt.HTMLJinjaTableBlock.HeaderCell('b', [('cc', 'b')], 1, 1),
+            abt.HTMLJinjaTableBlock.HeaderCell('c', [('cc', 'c')], 1, 1),
+            abt.HTMLJinjaTableBlock.HeaderCell('a', [('aa', 'a')], 1, 1),
+            abt.HTMLJinjaTableBlock.HeaderCell('b', [('aa', 'b')], 1, 1),
+            abt.HTMLJinjaTableBlock.HeaderCell('c', [('aa', 'c')], 1, 1),
+        ]
+    ]
     assert result == expected
 
 
@@ -144,4 +164,86 @@ def test__get_header_iterable_plain_index():
     p = pd.DataFrame(np.ones((4, 5)), columns=columns)
     t = abt.HTMLJinjaTableBlock(p)
     result = t._get_header_iterable()
-    assert result == [columns]
+    expected = [[
+        abt.HTMLJinjaTableBlock.HeaderCell('a', ['a'], 1, 1),
+        abt.HTMLJinjaTableBlock.HeaderCell('b', ['b'], 1, 1),
+        abt.HTMLJinjaTableBlock.HeaderCell('c', ['c'], 1, 1),
+        abt.HTMLJinjaTableBlock.HeaderCell('d', ['d'], 1, 1),
+        abt.HTMLJinjaTableBlock.HeaderCell('e', ['e'], 1, 1),
+    ]]
+    assert result == expected
+
+
+def test__vertical_merge():
+    """
+    should coalesce vertically if merge_vertical is passed, except for the
+    bottom cell. for example, the following multiindex:
+    """
+    columns = pd.MultiIndex.from_tuples([('a', 'a', 'a')])
+    p = pd.DataFrame([], columns=columns)
+    t = abt.HTMLJinjaTableBlock(p, merge_vertical=True)
+    result = t._get_header_iterable()
+    expected = [
+        [abt.HTMLJinjaTableBlock.HeaderCell('a', [('a', 'a', 'a')], 1, 2)],
+        [],
+        [abt.HTMLJinjaTableBlock.HeaderCell('a', [('a', 'a', 'a')], 1, 1)],
+    ]
+    assert result == expected
+
+
+def test__vertical_and_horizontal_merge():
+    columns = pd.MultiIndex.from_tuples([('a', 'a', 'a'), ('a', 'a', 'a')])
+    p = pd.DataFrame([], columns=columns)
+    t = abt.HTMLJinjaTableBlock(p, merge_vertical=True)
+    result = t._get_header_iterable()
+    expected = [
+        [abt.HTMLJinjaTableBlock.HeaderCell('a', [('a', 'a', 'a'), ('a', 'a', 'a')], 2, 2)],
+        [],
+        [
+            abt.HTMLJinjaTableBlock.HeaderCell('a', [('a', 'a', 'a')], 1, 1),
+            abt.HTMLJinjaTableBlock.HeaderCell('a', [('a', 'a', 'a')], 1, 1),
+        ],
+    ]
+    assert result == expected
+
+
+def test__no_vertical_merge():
+    """
+    should coalesce vertically if merge_vertical is passed, except for the
+    bottom cell. for example, the following multiindex:
+    """
+    columns = pd.MultiIndex.from_tuples([('a', 'a', 'a')])
+    p = pd.DataFrame([], columns=columns)
+    t = abt.HTMLJinjaTableBlock(p)
+    result = t._get_header_iterable()
+    expected = [
+        [abt.HTMLJinjaTableBlock.HeaderCell('a', [('a', 'a', 'a')], 1, 1)],
+        [abt.HTMLJinjaTableBlock.HeaderCell('a', [('a', 'a', 'a')], 1, 1)],
+        [abt.HTMLJinjaTableBlock.HeaderCell('a', [('a', 'a', 'a')], 1, 1)],
+    ]
+    assert result == expected
+
+
+def test__no_merge_if_parents_differ():
+    """
+    should not merge multiindex cells if their parent cells differ.
+    """
+    columns = pd.MultiIndex.from_tuples([('a', 'b', 'c'), ('c', 'b', 'a')])
+    p = pd.DataFrame([], columns=columns)
+    t = abt.HTMLJinjaTableBlock(p)
+    result = t._get_header_iterable()
+    expected = [
+        [
+            abt.HTMLJinjaTableBlock.HeaderCell('a', [('a', 'b', 'c')], 1, 1),
+            abt.HTMLJinjaTableBlock.HeaderCell('c', [('c', 'b', 'a')], 1, 1),
+        ],
+        [
+            abt.HTMLJinjaTableBlock.HeaderCell('b', [('a', 'b', 'c')], 1, 1),
+            abt.HTMLJinjaTableBlock.HeaderCell('b', [('c', 'b', 'a')], 1, 1),
+        ],
+        [
+            abt.HTMLJinjaTableBlock.HeaderCell('c', [('a', 'b', 'c')], 1, 1),
+            abt.HTMLJinjaTableBlock.HeaderCell('a', [('c', 'b', 'a')], 1, 1),
+        ],
+    ]
+    assert result == expected

--- a/tests/unit/block/test_table_formatters.py
+++ b/tests/unit/block/test_table_formatters.py
@@ -492,27 +492,27 @@ def test_FmtAppendTotalsRow_modify_dataframe():
     fmt = pbtf.FmtAppendTotalsRow()
     res = fmt._modify_dataframe(df)
     expected = pd.Series([9., 12., 15.], name='Total', index=[pbtf.INDEX_COL_NAME, 'aa', 'bb'])
-    assert expected.equals(res.ix[-1])
+    assert expected.equals(res.iloc[-1])
 
     fmt = pbtf.FmtAppendTotalsRow(operator=pbtf.OP_MEAN)
     res = fmt._modify_dataframe(df)
     expected = pd.Series([3., 4., 5.], name='Total', index=[pbtf.INDEX_COL_NAME, 'aa', 'bb'])
-    assert expected.equals(res.ix[-1])
+    assert expected.equals(res.iloc[-1])
 
     fmt = pbtf.FmtAppendTotalsRow(operator=pbtf.OP_NONE)
     res = fmt._modify_dataframe(df)
     expected = pd.Series(['', '', ''], name='Total', index=[pbtf.INDEX_COL_NAME, 'aa', 'bb'])
-    assert expected.equals(res.ix[-1])
+    assert expected.equals(res.iloc[-1])
 
     fmt = pbtf.FmtAppendTotalsRow(row_name=TEST_STRING)
     res = fmt._modify_dataframe(df)
     expected = pd.Series([9., 12., 15.], name=TEST_STRING, index=[pbtf.INDEX_COL_NAME, 'aa', 'bb'])
-    assert expected.equals(res.ix[-1])
+    assert expected.equals(res.iloc[-1])
 
     fmt = pbtf.FmtAppendTotalsRow(total_columns=['bb'])
     res = fmt._modify_dataframe(df)
     expected = pd.Series(['', '', 15.], name='Total', index=[pbtf.INDEX_COL_NAME, 'aa', 'bb'])
-    assert expected.equals(res.ix[-1])
+    assert expected.equals(res.iloc[-1])
 
 
 def test_FmtAppendTotalsRow_mixed_datatypes():
@@ -616,20 +616,20 @@ def test_FmtExpandMultiIndex_modify_dataframe():
     assert res.shape == (6, 4)
     assert res.index.tolist() == ['a', 'aa', 'ab', 'b', 'ba', 'bb']
     assert res.index.name == ''
-    assert res.ix['a'].tolist() == [3., 5., 7., ('a',)]
+    assert res.loc['a'].tolist() == [3., 5., 7., ('a',)]
     assert fmt.index_level == [0, 1, 1, 0, 1, 1]
 
     fmt = pbtf.FmtExpandMultiIndex(operator=pbtf.OP_MEAN)
     res = fmt._modify_dataframe(mi_df)
-    assert res.ix['a'].tolist() == [1.5, 2.5, 3.5, ('a',)]
+    assert res.loc['a'].tolist() == [1.5, 2.5, 3.5, ('a',)]
 
     fmt = pbtf.FmtExpandMultiIndex(operator=pbtf.OP_NONE)
     res = fmt._modify_dataframe(mi_df)
-    assert res.ix['a'].tolist() == ['', '', '', ('a',)]
+    assert res.loc['a'].tolist() == ['', '', '', ('a',)]
 
     fmt = pbtf.FmtExpandMultiIndex(operator=pbtf.OP_SUM, total_columns=['column1'])
     res = fmt._modify_dataframe(mi_df)
-    assert res.ix['a'].tolist() == ['', 5., '', ('a',)]
+    assert res.loc['a'].tolist() == ['', 5., '', ('a',)]
 
 
 def test_FmtExpandMultiIndex_cell_css():


### PR DESCRIPTION
* Fixes: FmtHeader column widths have an effect only on first header row
  If cells in the first header row belong to a MultiIndex and have been merged,
  then child cells can be smaller than expected due to the behaviour of
  `table-layout: fixed`.
  See https://www.w3.org/TR/css-tables-3/#width-distribution-in-fixed-mode
* Fixes: MultiIndex header cells are merged even if they differ on a higher level
* Fixes: `create_cell_level_css` and `modify_cell_content` are passed wrong
`data` and `column_name` values for MultiIndex header cells.
* Adds: `merge_vertical` argument to HTMLJinjaTableBlock, which enables
MultiIndex header cells to be merged vertically (between levels) as well as
horizontally (within level).

Example:
```
import pandas as pd
from pybloqs import VStack, Block
import pybloqs.block.table_formatters as tf
import pybloqs.block.colors as colors


columns = pd.MultiIndex.from_tuples([("aa", "aa", "vv"), ("aa", "aa", "ww"), ("bb", "bb", "xx"), ("cc", "bb", "yy"), ("cc", "dd", "yy"), ("cc", "dd", "zz")])
index = pd.Series(["0", "1"], name="Index")
df = pd.DataFrame(
    [
        [11, 22, 33, 44, 55, 66],
        [44, 55, 66, 77, 88, 99],
    ],
    columns=columns,
    index=index,
)

df_basic = pd.DataFrame(
    [
        [11, 22, 33, 44, 55, 66],
        [44, 55, 66, 77, 88, 99],
    ],
    columns=['aa', 'bb', 'cc', 'dd', 'ee', 'ff'],
    index=index,
)

class FmtCapitaliseD(tf.TableFormatter):
    def _modify_cell_content(self, data):
        return data.cell.replace("d", "D") if isinstance(data.cell, str) else data.cell

formatters = [
    tf.FmtHeader(index_width="80pt", column_width="40pt", fixed_width="240pt"),
    tf.FmtAddCellBorder(each=1, color=colors.GREY, apply_to_header_and_index=True),
    tf.FmtHighlightBackground(apply_to_header_and_index=False, rows=tf.HEADER_ROW_NAME, columns=[("bb", "bb", "xx")], color=colors.LIGHT_GREY),
    FmtCapitaliseD(),
]

block = Block(df, use_default_formatters=False, formatters=formatters, title="with defaults")
block_vert = Block(df, use_default_formatters=False, formatters=formatters, merge_vertical=True, title="with merge_vertical")
block_basic = Block(df_basic, use_default_formatters=False, formatters=formatters, merge_vertical=True, title="basic")

VStack([block, block_vert, block_basic]).save("/tmp/pybloqs.html")
```

Before:
![pybloqs-before](https://user-images.githubusercontent.com/977092/89572347-e32aaf80-d820-11ea-9692-916dd5a66e2a.png)

After:
![pybloqs-after](https://user-images.githubusercontent.com/977092/89572340-e2921900-d820-11ea-98aa-466d116e8e31.png)