### PR TITLE
Prepare for v1.2.12 - remove six

### DIFF
--- a/pybloqs/email.py
+++ b/pybloqs/email.py
@@ -18,7 +18,6 @@ import tempfile
 
 from html5lib import treebuilders
 import html5lib
-import six
 
 from pybloqs.config import user_config
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ import os
 from setuptools import setup, find_packages, Command
 from setuptools.command.install import install
 from setuptools.command.test import test as TestCommand
-import six
 import sys
 
 
@@ -152,7 +151,7 @@ class PyTest(TestCommand):
         # import here, cause outside the eggs aren't loaded
         import pytest
 
-        args = [self.pytest_args] if isinstance(self.pytest_args, six.string_types) else list(self.pytest_args)
+        args = [self.pytest_args] if isinstance(self.pytest_args, str) else list(self.pytest_args)
         args.extend(['--cov', 'pybloqs',
                      '--cov-report', 'xml',
                      '--cov-report', 'html',


### PR DESCRIPTION
Ran into issue following latest Python packaging instructions, `python3 -m build` would fail as `six` is not installed.