### PR TITLE
[docs, ci]: Fix readthedocs and remove cruft from built distributions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,8 +159,10 @@ jobs:
            else
              echo "Not on an exact tag: refusing to publish"
            fi
+         elif [[ $PYPI_INSTANCE == "none" ]]; then
+           echo "Not uploading"
          else
-           echo "Variable PYPI_INSTANCE must be set to either `live` or `test`."
+           echo "Variable PYPI_INSTANCE must be set to either \"live\" or \"test\" or \"none\"."
            exit 1
          fi
 workflows:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.8"
+    python: "3.11"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,7 @@
 include README.md
 include CHANGES.md
 include LICENSE
+prune .circleci
+prune docs
+prune logo
+prune tests

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 prune .circleci
 prune docs
 prune logo
+prune pybloqs/static/uncompressed
 prune tests

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 prune .circleci
+prune ci
 prune docs
 prune logo
 prune pybloqs/static/uncompressed

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,3 @@
-include README.md
-include CHANGES.md
-include LICENSE
 prune .circleci
 prune docs
 prune logo

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CircleCI](https://circleci.com/gh/man-group/PyBloqs.svg?style=shield)](https://circleci.com/gh/man-group/PyBloqs)
 [![PyPI](https://img.shields.io/pypi/pyversions/pybloqs.svg)](https://pypi.python.org/pypi/pybloqs/)
-[![ReadTheDocs](https://readthedocs.org/projects/pybloqsmain/badge)](https://pybloqsmain.readthedocs.io)
+[![ReadTheDocs](https://readthedocs.org/projects/pybloqs/badge)](https://pybloqs.readthedocs.io)
 [![Coverage Status](https://coveralls.io/repos/github/manahl/PyBloqs/badge.svg?branch=master)](https://coveralls.io/github/manahl/PyBloqs?branch=master)
 
 PyBloqs is a flexible framework for visualizing data and automated creation of reports. 
@@ -20,7 +20,7 @@ separately for fast development turnover. Lists of blocks can be stacked togethe
 
 ### Install PyBloqs
 
-See the [documentation](https://pybloqsmain.readthedocs.io/en/latest/installation.html) for installation instructions.
+See the [documentation](https://pybloqs.readthedocs.io/en/latest/installation.html) for installation instructions.
 
 ### Using PyBloqs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ name = "pybloqs"
 requires-python = ">= 3.6"
 authors = [{ name = "Man Alpha Technology", email = "ManAlphaTech@man.com" }]
 keywords = ["ahl", "pdf", "html", "visualization", "report"]
+license = { file = "LICENSE" }
 classifiers = [
   "Operating System :: OS Independent",
   "Intended Audience :: Science/Research",


### PR DESCRIPTION
This tweaks the `MANIFEST.in` and readthedocs configuration after the recent minor version update.