### PR TITLE
bugfix: Make Cfg objects explicitly pickle-able

### DIFF
--- a/pybloqs/util.py
+++ b/pybloqs/util.py
@@ -128,3 +128,10 @@ class Cfg(dict):
 
     def __setattr__(self, name, value):
         self[name] = value
+
+    def __setstate__(self, state):
+        for key in state:
+            self[key] = state[key]
+
+    def __getstate__(self):
+        return {key: self[key] for key in self}

--- a/tests/unit/test_pickle.py
+++ b/tests/unit/test_pickle.py
@@ -1,0 +1,21 @@
+import pickle
+
+import pandas
+
+import pybloqs
+
+
+def test_pickle_round_trip():
+    block = pybloqs.HStack(
+        [pybloqs.Block("Test contents", title="With title", border="1px solid black"), "second contents"]
+    )
+
+    round_trip = pickle.loads(pickle.dumps(block))
+    assert block.render_html() == round_trip.render_html()
+
+
+def test_pickle_round_with_dataframes():
+    block = pybloqs.Block(pandas.DataFrame({"foo": [1, 2, 3]}), title="With title")
+
+    round_trip = pickle.loads(pickle.dumps(block))
+    assert block.render_html() == round_trip.render_html()


### PR DESCRIPTION
This lets us pickle entire pybloqs. We also add some tests that the round trip is faithful.

This fixes #113 