### PR TITLE
Web based image handling in emails

### DIFF
--- a/pybloqs/email.py
+++ b/pybloqs/email.py
@@ -95,6 +95,10 @@ def _set_email_mime_types(dom, message=None, convert_to_ascii=False):
                 img_tag.parentNode.removeChild(img_tag)
                 continue
             img_data = base64.b64decode(imgdef[(imgdef.index("base64,") + 7) :])
+        elif src.startswith("http"):
+            # Web hosted images arn't on the filesystem
+            # and don't need to be changed
+            continue
         else:
             # get a unique name for the image
             name = f"{idx}_{os.path.basename(src)}"

--- a/pybloqs/email.py
+++ b/pybloqs/email.py
@@ -96,7 +96,7 @@ def _set_email_mime_types(dom, message=None, convert_to_ascii=False):
                 continue
             img_data = base64.b64decode(imgdef[(imgdef.index("base64,") + 7) :])
         elif src.startswith("http"):
-            # Web hosted images arn't on the filesystem
+            # Web hosted images aren't on the filesystem
             # and don't need to be changed
             continue
         else:


### PR DESCRIPTION
When web based image src is used the email software will be able to go and get the image.

If we try to fetch the http based src from the file system as currently happens a file not found error will be raised.

Since the image can be fetched and doesn't need to be attached if it is a web image we can skip