### PR TITLE
[ci] Pin ruff to minor version 0.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ defaults: &defaults
        command: |
          set -e
          . ci/bin/activate
-         pip install ruff
+         pip install "ruff<=0.7"
          ruff format --check pybloqs tests docs
     - run:
        name: Run lints


### PR DESCRIPTION
This prevents us picking up breaking changes in ruff 0.8 and higher without intentionally upgrading.