### PR TITLE
[bugfix] Return correct exception from __getattr__ on Cfg objects

### DIFF
--- a/pybloqs/util.py
+++ b/pybloqs/util.py
@@ -129,7 +129,10 @@ class Cfg(dict):
                 yield (k, dict2[k])
 
     def __getattr__(self, item: str):
-        return self[item]
+        try:
+            return self[item]
+        except KeyError:
+            raise AttributeError(f"'Cfg' object has no attribute '{item}'")
 
     def __setattr__(self, name: str, value):
         self[name] = value


### PR DESCRIPTION
We were raising KeyError here if `item` wasn't set in the Cfg object. However, `__getattr__` should raise `AttributeError`.