### PR TITLE
[bugfix] Use `utf-8` instead of `utf8` and remove unused UTF-8 tests

### DIFF
--- a/pybloqs/html.py
+++ b/pybloqs/html.py
@@ -38,7 +38,7 @@ def root(tag_name: str = "html", doctype: Optional[str] = None, **kwargs) -> bs4
     return tag
 
 
-def render(item: bs4.Tag, pretty: bool = True, encoding: str = "utf8") -> str:
+def render(item: bs4.Tag, pretty: bool = True, encoding: str = "utf-8") -> str:
     """
     Renders the given element into a string.
 
@@ -46,7 +46,7 @@ def render(item: bs4.Tag, pretty: bool = True, encoding: str = "utf8") -> str:
     :param pretty: Toggles pretty formatting of the resulting string.
     :return: Rendered content.
     """
-    return item.prettify(encoding=encoding).decode("utf8") if pretty else str(item)
+    return item.prettify(encoding=encoding).decode("utf-8") if pretty else str(item)
 
 
 def append_to(parent: bs4.PageElement, tag, **kwargs) -> bs4.Tag:

--- a/pybloqs/util.py
+++ b/pybloqs/util.py
@@ -31,7 +31,7 @@ def encode_string(string: str, level: int = 9) -> bytes:
     :param level: Compression level
     :return: Compressed and encoded string
     """
-    return base64.b64encode(zlib.compress(string.encode("utf8"), level)[2:-4])
+    return base64.b64encode(zlib.compress(string.encode("utf-8"), level)[2:-4])
 
 
 def camelcase(value: str) -> str:

--- a/tests/integration/generate/test_base.py
+++ b/tests/integration/generate/test_base.py
@@ -58,4 +58,4 @@ def test_save_pdf_dynamic_content():
 
 def test_meta_tags_in_head():
     output = Raw("test").render_html()
-    assert 'charset="utf8"' in output
+    assert 'charset="utf-8"' in output

--- a/tests/regression/html_output/empty.html
+++ b/tests/regression/html_output/empty.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
  <head>
-  <meta charset="utf8"/>
+  <meta charset="utf-8"/>
   <script type="text/javascript">
    if(typeof(_pybloqs_load_sentinel_jsinflate) == 'undefined'){(function(){var zip_WSIZE=32768;var zip_STORED_BLOCK=0;var zip_STATIC_TREES=1;var zip_DYN_TREES=2;var zip_lbits=9;var zip_dbits=6;var zip_INBUFSIZ=32768;var zip_INBUF_EXTRA=64;var zip_slide;var zip_wp;var zip_fixed_tl=null;var zip_fixed_td;var zip_fixed_bl,fixed_bd;var zip_bit_buf;var zip_bit_len;var zip_method;var zip_eof;var zip_copy_leng;var zip_copy_dist;var zip_tl,zip_td;var zip_bl,zip_bd;var zip_inflate_data;var zip_inflate_pos;var zip_MASK_BITS=new Array(0x0000,0x0001,0x0003,0x0007,0x000f,0x001f,0x003f,0x007f,0x00ff,0x01ff,0x03ff,0x07ff,0x0fff,0x1fff,0x3fff,0x7fff,0xffff);var zip_cplens=new Array(3,4,5,6,7,8,9,10,11,13,15,17,19,23,27,31,35,43,51,59,67,83,99,115,131,163,195,227,258,0,0);var zip_cplext=new Array(0,0,0,0,0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3,4,4,4,4,5,5,5,5,0,99,99);var zip_cpdist=new Array(1,2,3,4,5,7,9,13,17,25,33,49,65,97,129,193,257,385,513,769,1025,1537,2049,3073,4097,6145,8193,12289,16385,24577);var zip_cpdext=new Array(0,0,0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,9,9,10,10,11,11,12,12,13,13);var zip_border=new Array(16,17,18,0,8,7,9,6,10,5,11,4,12,3,13,2,14,1,15);var zip_HuftList=function(){this.next=null;this.list=null;}
 var zip_HuftNode=function(){this.e=0;this.b=0;this.n=0;this.t=null;}

--- a/tests/regression/html_output/flow.html
+++ b/tests/regression/html_output/flow.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
  <head>
-  <meta charset="utf8"/>
+  <meta charset="utf-8"/>
   <script type="text/javascript">
    if(typeof(_pybloqs_load_sentinel_jsinflate) == 'undefined'){(function(){var zip_WSIZE=32768;var zip_STORED_BLOCK=0;var zip_STATIC_TREES=1;var zip_DYN_TREES=2;var zip_lbits=9;var zip_dbits=6;var zip_INBUFSIZ=32768;var zip_INBUF_EXTRA=64;var zip_slide;var zip_wp;var zip_fixed_tl=null;var zip_fixed_td;var zip_fixed_bl,fixed_bd;var zip_bit_buf;var zip_bit_len;var zip_method;var zip_eof;var zip_copy_leng;var zip_copy_dist;var zip_tl,zip_td;var zip_bl,zip_bd;var zip_inflate_data;var zip_inflate_pos;var zip_MASK_BITS=new Array(0x0000,0x0001,0x0003,0x0007,0x000f,0x001f,0x003f,0x007f,0x00ff,0x01ff,0x03ff,0x07ff,0x0fff,0x1fff,0x3fff,0x7fff,0xffff);var zip_cplens=new Array(3,4,5,6,7,8,9,10,11,13,15,17,19,23,27,31,35,43,51,59,67,83,99,115,131,163,195,227,258,0,0);var zip_cplext=new Array(0,0,0,0,0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3,4,4,4,4,5,5,5,5,0,99,99);var zip_cpdist=new Array(1,2,3,4,5,7,9,13,17,25,33,49,65,97,129,193,257,385,513,769,1025,1537,2049,3073,4097,6145,8193,12289,16385,24577);var zip_cpdext=new Array(0,0,0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,9,9,10,10,11,11,12,12,13,13);var zip_border=new Array(16,17,18,0,8,7,9,6,10,5,11,4,12,3,13,2,14,1,15);var zip_HuftList=function(){this.next=null;this.list=null;}
 var zip_HuftNode=function(){this.e=0;this.b=0;this.n=0;this.t=null;}

--- a/tests/regression/html_output/grid.html
+++ b/tests/regression/html_output/grid.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
  <head>
-  <meta charset="utf8"/>
+  <meta charset="utf-8"/>
   <script type="text/javascript">
    if(typeof(_pybloqs_load_sentinel_jsinflate) == 'undefined'){(function(){var zip_WSIZE=32768;var zip_STORED_BLOCK=0;var zip_STATIC_TREES=1;var zip_DYN_TREES=2;var zip_lbits=9;var zip_dbits=6;var zip_INBUFSIZ=32768;var zip_INBUF_EXTRA=64;var zip_slide;var zip_wp;var zip_fixed_tl=null;var zip_fixed_td;var zip_fixed_bl,fixed_bd;var zip_bit_buf;var zip_bit_len;var zip_method;var zip_eof;var zip_copy_leng;var zip_copy_dist;var zip_tl,zip_td;var zip_bl,zip_bd;var zip_inflate_data;var zip_inflate_pos;var zip_MASK_BITS=new Array(0x0000,0x0001,0x0003,0x0007,0x000f,0x001f,0x003f,0x007f,0x00ff,0x01ff,0x03ff,0x07ff,0x0fff,0x1fff,0x3fff,0x7fff,0xffff);var zip_cplens=new Array(3,4,5,6,7,8,9,10,11,13,15,17,19,23,27,31,35,43,51,59,67,83,99,115,131,163,195,227,258,0,0);var zip_cplext=new Array(0,0,0,0,0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3,4,4,4,4,5,5,5,5,0,99,99);var zip_cpdist=new Array(1,2,3,4,5,7,9,13,17,25,33,49,65,97,129,193,257,385,513,769,1025,1537,2049,3073,4097,6145,8193,12289,16385,24577);var zip_cpdext=new Array(0,0,0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,9,9,10,10,11,11,12,12,13,13);var zip_border=new Array(16,17,18,0,8,7,9,6,10,5,11,4,12,3,13,2,14,1,15);var zip_HuftList=function(){this.next=null;this.list=null;}
 var zip_HuftNode=function(){this.e=0;this.b=0;this.n=0;this.t=null;}

--- a/tests/regression/html_output/hrule.html
+++ b/tests/regression/html_output/hrule.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
  <head>
-  <meta charset="utf8"/>
+  <meta charset="utf-8"/>
   <script type="text/javascript">
    if(typeof(_pybloqs_load_sentinel_jsinflate) == 'undefined'){(function(){var zip_WSIZE=32768;var zip_STORED_BLOCK=0;var zip_STATIC_TREES=1;var zip_DYN_TREES=2;var zip_lbits=9;var zip_dbits=6;var zip_INBUFSIZ=32768;var zip_INBUF_EXTRA=64;var zip_slide;var zip_wp;var zip_fixed_tl=null;var zip_fixed_td;var zip_fixed_bl,fixed_bd;var zip_bit_buf;var zip_bit_len;var zip_method;var zip_eof;var zip_copy_leng;var zip_copy_dist;var zip_tl,zip_td;var zip_bl,zip_bd;var zip_inflate_data;var zip_inflate_pos;var zip_MASK_BITS=new Array(0x0000,0x0001,0x0003,0x0007,0x000f,0x001f,0x003f,0x007f,0x00ff,0x01ff,0x03ff,0x07ff,0x0fff,0x1fff,0x3fff,0x7fff,0xffff);var zip_cplens=new Array(3,4,5,6,7,8,9,10,11,13,15,17,19,23,27,31,35,43,51,59,67,83,99,115,131,163,195,227,258,0,0);var zip_cplext=new Array(0,0,0,0,0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3,4,4,4,4,5,5,5,5,0,99,99);var zip_cpdist=new Array(1,2,3,4,5,7,9,13,17,25,33,49,65,97,129,193,257,385,513,769,1025,1537,2049,3073,4097,6145,8193,12289,16385,24577);var zip_cpdext=new Array(0,0,0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,9,9,10,10,11,11,12,12,13,13);var zip_border=new Array(16,17,18,0,8,7,9,6,10,5,11,4,12,3,13,2,14,1,15);var zip_HuftList=function(){this.next=null;this.list=null;}
 var zip_HuftNode=function(){this.e=0;this.b=0;this.n=0;this.t=null;}

--- a/tests/regression/html_output/hstack.html
+++ b/tests/regression/html_output/hstack.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
  <head>
-  <meta charset="utf8"/>
+  <meta charset="utf-8"/>
   <script type="text/javascript">
    if(typeof(_pybloqs_load_sentinel_jsinflate) == 'undefined'){(function(){var zip_WSIZE=32768;var zip_STORED_BLOCK=0;var zip_STATIC_TREES=1;var zip_DYN_TREES=2;var zip_lbits=9;var zip_dbits=6;var zip_INBUFSIZ=32768;var zip_INBUF_EXTRA=64;var zip_slide;var zip_wp;var zip_fixed_tl=null;var zip_fixed_td;var zip_fixed_bl,fixed_bd;var zip_bit_buf;var zip_bit_len;var zip_method;var zip_eof;var zip_copy_leng;var zip_copy_dist;var zip_tl,zip_td;var zip_bl,zip_bd;var zip_inflate_data;var zip_inflate_pos;var zip_MASK_BITS=new Array(0x0000,0x0001,0x0003,0x0007,0x000f,0x001f,0x003f,0x007f,0x00ff,0x01ff,0x03ff,0x07ff,0x0fff,0x1fff,0x3fff,0x7fff,0xffff);var zip_cplens=new Array(3,4,5,6,7,8,9,10,11,13,15,17,19,23,27,31,35,43,51,59,67,83,99,115,131,163,195,227,258,0,0);var zip_cplext=new Array(0,0,0,0,0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3,4,4,4,4,5,5,5,5,0,99,99);var zip_cpdist=new Array(1,2,3,4,5,7,9,13,17,25,33,49,65,97,129,193,257,385,513,769,1025,1537,2049,3073,4097,6145,8193,12289,16385,24577);var zip_cpdext=new Array(0,0,0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,9,9,10,10,11,11,12,12,13,13);var zip_border=new Array(16,17,18,0,8,7,9,6,10,5,11,4,12,3,13,2,14,1,15);var zip_HuftList=function(){this.next=null;this.list=null;}
 var zip_HuftNode=function(){this.e=0;this.b=0;this.n=0;this.t=null;}

--- a/tests/regression/html_output/markdown.html
+++ b/tests/regression/html_output/markdown.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
  <head>
-  <meta charset="utf8"/>
+  <meta charset="utf-8"/>
   <script type="text/javascript">
    if(typeof(_pybloqs_load_sentinel_jsinflate) == 'undefined'){(function(){var zip_WSIZE=32768;var zip_STORED_BLOCK=0;var zip_STATIC_TREES=1;var zip_DYN_TREES=2;var zip_lbits=9;var zip_dbits=6;var zip_INBUFSIZ=32768;var zip_INBUF_EXTRA=64;var zip_slide;var zip_wp;var zip_fixed_tl=null;var zip_fixed_td;var zip_fixed_bl,fixed_bd;var zip_bit_buf;var zip_bit_len;var zip_method;var zip_eof;var zip_copy_leng;var zip_copy_dist;var zip_tl,zip_td;var zip_bl,zip_bd;var zip_inflate_data;var zip_inflate_pos;var zip_MASK_BITS=new Array(0x0000,0x0001,0x0003,0x0007,0x000f,0x001f,0x003f,0x007f,0x00ff,0x01ff,0x03ff,0x07ff,0x0fff,0x1fff,0x3fff,0x7fff,0xffff);var zip_cplens=new Array(3,4,5,6,7,8,9,10,11,13,15,17,19,23,27,31,35,43,51,59,67,83,99,115,131,163,195,227,258,0,0);var zip_cplext=new Array(0,0,0,0,0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3,4,4,4,4,5,5,5,5,0,99,99);var zip_cpdist=new Array(1,2,3,4,5,7,9,13,17,25,33,49,65,97,129,193,257,385,513,769,1025,1537,2049,3073,4097,6145,8193,12289,16385,24577);var zip_cpdext=new Array(0,0,0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,9,9,10,10,11,11,12,12,13,13);var zip_border=new Array(16,17,18,0,8,7,9,6,10,5,11,4,12,3,13,2,14,1,15);var zip_HuftList=function(){this.next=null;this.list=null;}
 var zip_HuftNode=function(){this.e=0;this.b=0;this.n=0;this.t=null;}

--- a/tests/regression/html_output/nested.html
+++ b/tests/regression/html_output/nested.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
  <head>
-  <meta charset="utf8"/>
+  <meta charset="utf-8"/>
   <script type="text/javascript">
    if(typeof(_pybloqs_load_sentinel_jsinflate) == 'undefined'){(function(){var zip_WSIZE=32768;var zip_STORED_BLOCK=0;var zip_STATIC_TREES=1;var zip_DYN_TREES=2;var zip_lbits=9;var zip_dbits=6;var zip_INBUFSIZ=32768;var zip_INBUF_EXTRA=64;var zip_slide;var zip_wp;var zip_fixed_tl=null;var zip_fixed_td;var zip_fixed_bl,fixed_bd;var zip_bit_buf;var zip_bit_len;var zip_method;var zip_eof;var zip_copy_leng;var zip_copy_dist;var zip_tl,zip_td;var zip_bl,zip_bd;var zip_inflate_data;var zip_inflate_pos;var zip_MASK_BITS=new Array(0x0000,0x0001,0x0003,0x0007,0x000f,0x001f,0x003f,0x007f,0x00ff,0x01ff,0x03ff,0x07ff,0x0fff,0x1fff,0x3fff,0x7fff,0xffff);var zip_cplens=new Array(3,4,5,6,7,8,9,10,11,13,15,17,19,23,27,31,35,43,51,59,67,83,99,115,131,163,195,227,258,0,0);var zip_cplext=new Array(0,0,0,0,0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3,4,4,4,4,5,5,5,5,0,99,99);var zip_cpdist=new Array(1,2,3,4,5,7,9,13,17,25,33,49,65,97,129,193,257,385,513,769,1025,1537,2049,3073,4097,6145,8193,12289,16385,24577);var zip_cpdext=new Array(0,0,0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,9,9,10,10,11,11,12,12,13,13);var zip_border=new Array(16,17,18,0,8,7,9,6,10,5,11,4,12,3,13,2,14,1,15);var zip_HuftList=function(){this.next=null;this.list=null;}
 var zip_HuftNode=function(){this.e=0;this.b=0;this.n=0;this.t=null;}

--- a/tests/regression/html_output/pre.html
+++ b/tests/regression/html_output/pre.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
  <head>
-  <meta charset="utf8"/>
+  <meta charset="utf-8"/>
   <script type="text/javascript">
    if(typeof(_pybloqs_load_sentinel_jsinflate) == 'undefined'){(function(){var zip_WSIZE=32768;var zip_STORED_BLOCK=0;var zip_STATIC_TREES=1;var zip_DYN_TREES=2;var zip_lbits=9;var zip_dbits=6;var zip_INBUFSIZ=32768;var zip_INBUF_EXTRA=64;var zip_slide;var zip_wp;var zip_fixed_tl=null;var zip_fixed_td;var zip_fixed_bl,fixed_bd;var zip_bit_buf;var zip_bit_len;var zip_method;var zip_eof;var zip_copy_leng;var zip_copy_dist;var zip_tl,zip_td;var zip_bl,zip_bd;var zip_inflate_data;var zip_inflate_pos;var zip_MASK_BITS=new Array(0x0000,0x0001,0x0003,0x0007,0x000f,0x001f,0x003f,0x007f,0x00ff,0x01ff,0x03ff,0x07ff,0x0fff,0x1fff,0x3fff,0x7fff,0xffff);var zip_cplens=new Array(3,4,5,6,7,8,9,10,11,13,15,17,19,23,27,31,35,43,51,59,67,83,99,115,131,163,195,227,258,0,0);var zip_cplext=new Array(0,0,0,0,0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3,4,4,4,4,5,5,5,5,0,99,99);var zip_cpdist=new Array(1,2,3,4,5,7,9,13,17,25,33,49,65,97,129,193,257,385,513,769,1025,1537,2049,3073,4097,6145,8193,12289,16385,24577);var zip_cpdext=new Array(0,0,0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,9,9,10,10,11,11,12,12,13,13);var zip_border=new Array(16,17,18,0,8,7,9,6,10,5,11,4,12,3,13,2,14,1,15);var zip_HuftList=function(){this.next=null;this.list=null;}
 var zip_HuftNode=function(){this.e=0;this.b=0;this.n=0;this.t=null;}

--- a/tests/regression/html_output/raw.html
+++ b/tests/regression/html_output/raw.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
  <head>
-  <meta charset="utf8"/>
+  <meta charset="utf-8"/>
   <script type="text/javascript">
    if(typeof(_pybloqs_load_sentinel_jsinflate) == 'undefined'){(function(){var zip_WSIZE=32768;var zip_STORED_BLOCK=0;var zip_STATIC_TREES=1;var zip_DYN_TREES=2;var zip_lbits=9;var zip_dbits=6;var zip_INBUFSIZ=32768;var zip_INBUF_EXTRA=64;var zip_slide;var zip_wp;var zip_fixed_tl=null;var zip_fixed_td;var zip_fixed_bl,fixed_bd;var zip_bit_buf;var zip_bit_len;var zip_method;var zip_eof;var zip_copy_leng;var zip_copy_dist;var zip_tl,zip_td;var zip_bl,zip_bd;var zip_inflate_data;var zip_inflate_pos;var zip_MASK_BITS=new Array(0x0000,0x0001,0x0003,0x0007,0x000f,0x001f,0x003f,0x007f,0x00ff,0x01ff,0x03ff,0x07ff,0x0fff,0x1fff,0x3fff,0x7fff,0xffff);var zip_cplens=new Array(3,4,5,6,7,8,9,10,11,13,15,17,19,23,27,31,35,43,51,59,67,83,99,115,131,163,195,227,258,0,0);var zip_cplext=new Array(0,0,0,0,0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3,4,4,4,4,5,5,5,5,0,99,99);var zip_cpdist=new Array(1,2,3,4,5,7,9,13,17,25,33,49,65,97,129,193,257,385,513,769,1025,1537,2049,3073,4097,6145,8193,12289,16385,24577);var zip_cpdext=new Array(0,0,0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,9,9,10,10,11,11,12,12,13,13);var zip_border=new Array(16,17,18,0,8,7,9,6,10,5,11,4,12,3,13,2,14,1,15);var zip_HuftList=function(){this.next=null;this.list=null;}
 var zip_HuftNode=function(){this.e=0;this.b=0;this.n=0;this.t=null;}

--- a/tests/regression/html_output/span.html
+++ b/tests/regression/html_output/span.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
  <head>
-  <meta charset="utf8"/>
+  <meta charset="utf-8"/>
   <script type="text/javascript">
    if(typeof(_pybloqs_load_sentinel_jsinflate) == 'undefined'){(function(){var zip_WSIZE=32768;var zip_STORED_BLOCK=0;var zip_STATIC_TREES=1;var zip_DYN_TREES=2;var zip_lbits=9;var zip_dbits=6;var zip_INBUFSIZ=32768;var zip_INBUF_EXTRA=64;var zip_slide;var zip_wp;var zip_fixed_tl=null;var zip_fixed_td;var zip_fixed_bl,fixed_bd;var zip_bit_buf;var zip_bit_len;var zip_method;var zip_eof;var zip_copy_leng;var zip_copy_dist;var zip_tl,zip_td;var zip_bl,zip_bd;var zip_inflate_data;var zip_inflate_pos;var zip_MASK_BITS=new Array(0x0000,0x0001,0x0003,0x0007,0x000f,0x001f,0x003f,0x007f,0x00ff,0x01ff,0x03ff,0x07ff,0x0fff,0x1fff,0x3fff,0x7fff,0xffff);var zip_cplens=new Array(3,4,5,6,7,8,9,10,11,13,15,17,19,23,27,31,35,43,51,59,67,83,99,115,131,163,195,227,258,0,0);var zip_cplext=new Array(0,0,0,0,0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3,4,4,4,4,5,5,5,5,0,99,99);var zip_cpdist=new Array(1,2,3,4,5,7,9,13,17,25,33,49,65,97,129,193,257,385,513,769,1025,1537,2049,3073,4097,6145,8193,12289,16385,24577);var zip_cpdext=new Array(0,0,0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,9,9,10,10,11,11,12,12,13,13);var zip_border=new Array(16,17,18,0,8,7,9,6,10,5,11,4,12,3,13,2,14,1,15);var zip_HuftList=function(){this.next=null;this.list=null;}
 var zip_HuftNode=function(){this.e=0;this.b=0;this.n=0;this.t=null;}

--- a/tests/regression/html_output/title.html
+++ b/tests/regression/html_output/title.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
  <head>
-  <meta charset="utf8"/>
+  <meta charset="utf-8"/>
   <script type="text/javascript">
    if(typeof(_pybloqs_load_sentinel_jsinflate) == 'undefined'){(function(){var zip_WSIZE=32768;var zip_STORED_BLOCK=0;var zip_STATIC_TREES=1;var zip_DYN_TREES=2;var zip_lbits=9;var zip_dbits=6;var zip_INBUFSIZ=32768;var zip_INBUF_EXTRA=64;var zip_slide;var zip_wp;var zip_fixed_tl=null;var zip_fixed_td;var zip_fixed_bl,fixed_bd;var zip_bit_buf;var zip_bit_len;var zip_method;var zip_eof;var zip_copy_leng;var zip_copy_dist;var zip_tl,zip_td;var zip_bl,zip_bd;var zip_inflate_data;var zip_inflate_pos;var zip_MASK_BITS=new Array(0x0000,0x0001,0x0003,0x0007,0x000f,0x001f,0x003f,0x007f,0x00ff,0x01ff,0x03ff,0x07ff,0x0fff,0x1fff,0x3fff,0x7fff,0xffff);var zip_cplens=new Array(3,4,5,6,7,8,9,10,11,13,15,17,19,23,27,31,35,43,51,59,67,83,99,115,131,163,195,227,258,0,0);var zip_cplext=new Array(0,0,0,0,0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3,4,4,4,4,5,5,5,5,0,99,99);var zip_cpdist=new Array(1,2,3,4,5,7,9,13,17,25,33,49,65,97,129,193,257,385,513,769,1025,1537,2049,3073,4097,6145,8193,12289,16385,24577);var zip_cpdext=new Array(0,0,0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,9,9,10,10,11,11,12,12,13,13);var zip_border=new Array(16,17,18,0,8,7,9,6,10,5,11,4,12,3,13,2,14,1,15);var zip_HuftList=function(){this.next=null;this.list=null;}
 var zip_HuftNode=function(){this.e=0;this.b=0;this.n=0;this.t=null;}

--- a/tests/regression/html_output/title_levels.html
+++ b/tests/regression/html_output/title_levels.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
  <head>
-  <meta charset="utf8"/>
+  <meta charset="utf-8"/>
   <script type="text/javascript">
    if(typeof(_pybloqs_load_sentinel_jsinflate) == 'undefined'){(function(){var zip_WSIZE=32768;var zip_STORED_BLOCK=0;var zip_STATIC_TREES=1;var zip_DYN_TREES=2;var zip_lbits=9;var zip_dbits=6;var zip_INBUFSIZ=32768;var zip_INBUF_EXTRA=64;var zip_slide;var zip_wp;var zip_fixed_tl=null;var zip_fixed_td;var zip_fixed_bl,fixed_bd;var zip_bit_buf;var zip_bit_len;var zip_method;var zip_eof;var zip_copy_leng;var zip_copy_dist;var zip_tl,zip_td;var zip_bl,zip_bd;var zip_inflate_data;var zip_inflate_pos;var zip_MASK_BITS=new Array(0x0000,0x0001,0x0003,0x0007,0x000f,0x001f,0x003f,0x007f,0x00ff,0x01ff,0x03ff,0x07ff,0x0fff,0x1fff,0x3fff,0x7fff,0xffff);var zip_cplens=new Array(3,4,5,6,7,8,9,10,11,13,15,17,19,23,27,31,35,43,51,59,67,83,99,115,131,163,195,227,258,0,0);var zip_cplext=new Array(0,0,0,0,0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3,4,4,4,4,5,5,5,5,0,99,99);var zip_cpdist=new Array(1,2,3,4,5,7,9,13,17,25,33,49,65,97,129,193,257,385,513,769,1025,1537,2049,3073,4097,6145,8193,12289,16385,24577);var zip_cpdext=new Array(0,0,0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,9,9,10,10,11,11,12,12,13,13);var zip_border=new Array(16,17,18,0,8,7,9,6,10,5,11,4,12,3,13,2,14,1,15);var zip_HuftList=function(){this.next=null;this.list=null;}
 var zip_HuftNode=function(){this.e=0;this.b=0;this.n=0;this.t=null;}

--- a/tests/regression/html_output/vstack.html
+++ b/tests/regression/html_output/vstack.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
  <head>
-  <meta charset="utf8"/>
+  <meta charset="utf-8"/>
   <script type="text/javascript">
    if(typeof(_pybloqs_load_sentinel_jsinflate) == 'undefined'){(function(){var zip_WSIZE=32768;var zip_STORED_BLOCK=0;var zip_STATIC_TREES=1;var zip_DYN_TREES=2;var zip_lbits=9;var zip_dbits=6;var zip_INBUFSIZ=32768;var zip_INBUF_EXTRA=64;var zip_slide;var zip_wp;var zip_fixed_tl=null;var zip_fixed_td;var zip_fixed_bl,fixed_bd;var zip_bit_buf;var zip_bit_len;var zip_method;var zip_eof;var zip_copy_leng;var zip_copy_dist;var zip_tl,zip_td;var zip_bl,zip_bd;var zip_inflate_data;var zip_inflate_pos;var zip_MASK_BITS=new Array(0x0000,0x0001,0x0003,0x0007,0x000f,0x001f,0x003f,0x007f,0x00ff,0x01ff,0x03ff,0x07ff,0x0fff,0x1fff,0x3fff,0x7fff,0xffff);var zip_cplens=new Array(3,4,5,6,7,8,9,10,11,13,15,17,19,23,27,31,35,43,51,59,67,83,99,115,131,163,195,227,258,0,0);var zip_cplext=new Array(0,0,0,0,0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3,4,4,4,4,5,5,5,5,0,99,99);var zip_cpdist=new Array(1,2,3,4,5,7,9,13,17,25,33,49,65,97,129,193,257,385,513,769,1025,1537,2049,3073,4097,6145,8193,12289,16385,24577);var zip_cpdext=new Array(0,0,0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,9,9,10,10,11,11,12,12,13,13);var zip_border=new Array(16,17,18,0,8,7,9,6,10,5,11,4,12,3,13,2,14,1,15);var zip_HuftList=function(){this.next=null;this.list=null;}
 var zip_HuftNode=function(){this.e=0;this.b=0;this.n=0;this.t=null;}


### PR DESCRIPTION
Addresses #135 