### PR TITLE
Fix resource decompression when resource has multi-byte characters

### DIFF
--- a/pybloqs/block/base.py
+++ b/pybloqs/block/base.py
@@ -60,6 +60,7 @@ class BaseBlock:
         static_output: bool = False,
         header_block: Optional["BaseBlock"] = None,
         footer_block: Optional["BaseBlock"] = None,
+        permit_compression: bool = True,
     ) -> str:
         """
         Returns html output of the block
@@ -68,6 +69,7 @@ class BaseBlock:
         :param static_output: Passed down to _write_block. Will render static version of blocks which support this.
         :param header_block: If not None, header_block is inlined into a HTML body as table.
         :param footer_block: If not None, footer_block is inlined into a HTML body as table.
+        :param permit_compression: If set, resources will be embedded as base64 gzipped files
         :return html-code of the block
         """
         # Render the contents
@@ -114,7 +116,8 @@ class BaseBlock:
         else:
             self._write_block(body, Cfg(), id_generator(), resource_deps=resource_deps, static_output=static_output)
 
-        script_inflate.write(head)
+        if permit_compression:
+            script_inflate.write(head)
         script_block_core.write(head)
 
         if static_output:
@@ -123,7 +126,7 @@ class BaseBlock:
 
         # Write out resources
         for res in resource_deps:
-            res.write(head)
+            res.write(head, permit_compression=permit_compression)
 
         # Render the whole document (the parent of the html tag)
         content = render(html.parent, pretty=pretty)

--- a/pybloqs/htmlconv/wkhtmltox.py
+++ b/pybloqs/htmlconv/wkhtmltox.py
@@ -57,20 +57,20 @@ class WkhtmltopdfConverter(HTMLConverter):
         [cmd.extend([k, v]) for k, v in kwargs.items()]
 
         # Render without header and footer as those are handles explicitly below
-        content = block.render_html(static_output=True)
+        content = block.render_html(static_output=True, permit_compression=False)
         html_filename = HTMLConverter.write_html_to_tempfile(block, content)
 
         temp_files = [html_filename]
 
         if header_block is not None:
-            header_content = header_block.render_html(static_output=True)
+            header_content = header_block.render_html(static_output=True, permit_compression=False)
             header_filename = HTMLConverter.write_html_to_tempfile(header_block, header_content)
             cmd += ["--header-html", header_filename]
             cmd += ["--header-spacing", str(header_spacing)]
             temp_files.append(header_filename)
 
         if footer_block is not None:
-            footer_content = footer_block.render_html(static_output=True)
+            footer_content = footer_block.render_html(static_output=True, permit_compression=False)
             footer_filename = HTMLConverter.write_html_to_tempfile(footer_block, footer_content)
             cmd += ["--footer-html", footer_filename]
             cmd += ["--footer-spacing", str(footer_spacing)]
@@ -93,7 +93,7 @@ class WkhtmltoimageConverter(HTMLConverter):
         :param pdf_zoom: The zooming to apply when rendering the page.
         :param kwargs: Additional parameters. Passed to wkhtmltoimage.
         """
-        content = block.render_html(static_output=True)
+        content = block.render_html(static_output=True, permit_compression=False)
         html_filename = HTMLConverter.write_html_to_tempfile(block, content)
 
         cmd = []

--- a/pybloqs/plot/core.py
+++ b/pybloqs/plot/core.py
@@ -401,18 +401,13 @@ class Plot(BaseBlock):
             f"if(container){{clearInterval({js_timer_var_name});"
         )
 
-        # Write out the chart script into a separate buffer before running it through
-        # the encoding/compression
-        chart_buf = StringIO()
-        chart_buf.write("var cfg=")
-        self._write_dict(chart_buf, chart_cfg)
-        chart_buf.write(";")
+        stream.write("var cfg=")
+        self._write_dict(stream, chart_cfg)
+        stream.write(";")
 
-        chart_buf.write("var chart = new Highcharts." + self._chart_cls + "(cfg);")
+        stream.write("var chart = new Highcharts." + self._chart_cls + "(cfg);")
 
-        self._write_plot_postprocess(chart_buf)
-
-        JScript.write_compressed(stream, chart_buf.getvalue())
+        self._write_plot_postprocess(stream)
 
         stream.write("}},10);")
 

--- a/pybloqs/static/jsinflate.js
+++ b/pybloqs/static/jsinflate.js
@@ -101,7 +101,6 @@ if(i==-1){if(zip_eof)
 return 0;return-1;}
 n+=i;}
 return n;}
-var zip_inflate=function(str){var i,j;zip_inflate_start();zip_inflate_data=str;zip_inflate_pos=0;var buff=new Array(1024);var aout=[];while((i=zip_inflate_internal(buff,0,buff.length))>0){var cbuf=new Array(i);for(j=0;j<i;j++){cbuf[j]=String.fromCharCode(buff[j]);}
-aout[aout.length]=cbuf.join("");}
+var zip_inflate=function(str){var i,j;zip_inflate_start();zip_inflate_data=str;zip_inflate_pos=0;var buff=new Uint8Array(1024);var aout=[];var decoder=new TextDecoder("utf-8");while((i=zip_inflate_internal(buff,0,buff.length))>0){aout[aout.length]=decoder.decode(buff.slice(0,i));}
 zip_inflate_data=null;return aout.join("");}
 if(!window.RawDeflate)RawDeflate={};RawDeflate.inflate=zip_inflate;})();

--- a/pybloqs/static/uncompressed/jsinflate.js
+++ b/pybloqs/static/uncompressed/jsinflate.js
@@ -734,14 +734,13 @@ var zip_inflate = function(str) {
     zip_inflate_data = str;
     zip_inflate_pos = 0;
 
-    var buff = new Array(1024);
+    var buff = new Uint8Array(1024);
     var aout = [];
+	var decoder = new TextDecoder("utf-8");
     while((i = zip_inflate_internal(buff, 0, buff.length)) > 0) {
-	var cbuf = new Array(i);
-	for(j = 0; j < i; j++){
-	    cbuf[j] = String.fromCharCode(buff[j]);
-	}
-	aout[aout.length] = cbuf.join("");
+	// FIXME: This has a bug if the zip_inflate_internal breaks inside
+    //        a charpoint.
+	aout[aout.length] = decoder.decode(buff.slice(0, i));
     }
     zip_inflate_data = null; // G.C.
     return aout.join("");

--- a/tests/regression/html_output/empty.html
+++ b/tests/regression/html_output/empty.html
@@ -109,7 +109,8 @@ return n;}
 var zip_inflate=function(str){var i,j;zip_inflate_start();zip_inflate_data=str;zip_inflate_pos=0;var buff=new Array(1024);var aout=[];while((i=zip_inflate_internal(buff,0,buff.length))>0){var cbuf=new Array(i);for(j=0;j<i;j++){cbuf[j]=String.fromCharCode(buff[j]);}
 aout[aout.length]=cbuf.join("");}
 zip_inflate_data=null;return aout.join("");}
-if(!window.RawDeflate)RawDeflate={};RawDeflate.inflate=zip_inflate;})();_pybloqs_load_sentinel_jsinflate = true;}
+if(!window.RawDeflate)RawDeflate={};RawDeflate.inflate=zip_inflate;})();
+_pybloqs_load_sentinel_jsinflate = true;}
   </script>
   <script type="text/javascript">
    if(typeof(_pybloqs_load_sentinel_block_core) == 'undefined'){function isIE(){var myNav=navigator.userAgent.toLowerCase();return(myNav.indexOf('msie')!=-1)?parseInt(myNav.split('msie')[1]):false;}
@@ -119,7 +120,8 @@ function registerWaitHandle(handle){if(!window.loadWaitHandleRegistry){window.lo
 loadWaitHandleRegistry[handle]=false;}
 function setLoaded(handle){loadWaitHandleRegistry[handle]=true;}
 function runWaitPoller(){var loadWaitPoller=setInterval(function(){if("loadWaitHandleRegistry"in window){var handleCount=0;for(var handle in loadWaitHandleRegistry){if(!loadWaitHandleRegistry.hasOwnProperty(handle)){handleCount++;if(!loadWaitHandleRegistry[handle]){return}}}}
-clearInterval(loadWaitPoller);window.print();},10);return loadWaitPoller;}_pybloqs_load_sentinel_block_core = true;}
+clearInterval(loadWaitPoller);window.print();},10);return loadWaitPoller;}
+_pybloqs_load_sentinel_block_core = true;}
   </script>
   <style type="text/css">
    .pybloqs {

--- a/tests/regression/html_output/empty.html
+++ b/tests/regression/html_output/empty.html
@@ -106,10 +106,10 @@ if(i==-1){if(zip_eof)
 return 0;return-1;}
 n+=i;}
 return n;}
-var zip_inflate=function(str){var i,j;zip_inflate_start();zip_inflate_data=str;zip_inflate_pos=0;var buff=new Array(1024);var aout=[];while((i=zip_inflate_internal(buff,0,buff.length))>0){var cbuf=new Array(i);for(j=0;j<i;j++){cbuf[j]=String.fromCharCode(buff[j]);}
-aout[aout.length]=cbuf.join("");}
+var zip_inflate=function(str){var i,j;zip_inflate_start();zip_inflate_data=str;zip_inflate_pos=0;var buff=new Uint8Array(1024);var aout=[];var decoder=new TextDecoder("utf-8");while((i=zip_inflate_internal(buff,0,buff.length))>0){aout[aout.length]=decoder.decode(buff.slice(0,i));}
 zip_inflate_data=null;return aout.join("");}
 if(!window.RawDeflate)RawDeflate={};RawDeflate.inflate=zip_inflate;})();
+
 _pybloqs_load_sentinel_jsinflate = true;}
   </script>
   <script type="text/javascript">

--- a/tests/regression/html_output/flow.html
+++ b/tests/regression/html_output/flow.html
@@ -109,7 +109,8 @@ return n;}
 var zip_inflate=function(str){var i,j;zip_inflate_start();zip_inflate_data=str;zip_inflate_pos=0;var buff=new Array(1024);var aout=[];while((i=zip_inflate_internal(buff,0,buff.length))>0){var cbuf=new Array(i);for(j=0;j<i;j++){cbuf[j]=String.fromCharCode(buff[j]);}
 aout[aout.length]=cbuf.join("");}
 zip_inflate_data=null;return aout.join("");}
-if(!window.RawDeflate)RawDeflate={};RawDeflate.inflate=zip_inflate;})();_pybloqs_load_sentinel_jsinflate = true;}
+if(!window.RawDeflate)RawDeflate={};RawDeflate.inflate=zip_inflate;})();
+_pybloqs_load_sentinel_jsinflate = true;}
   </script>
   <script type="text/javascript">
    if(typeof(_pybloqs_load_sentinel_block_core) == 'undefined'){function isIE(){var myNav=navigator.userAgent.toLowerCase();return(myNav.indexOf('msie')!=-1)?parseInt(myNav.split('msie')[1]):false;}
@@ -119,7 +120,8 @@ function registerWaitHandle(handle){if(!window.loadWaitHandleRegistry){window.lo
 loadWaitHandleRegistry[handle]=false;}
 function setLoaded(handle){loadWaitHandleRegistry[handle]=true;}
 function runWaitPoller(){var loadWaitPoller=setInterval(function(){if("loadWaitHandleRegistry"in window){var handleCount=0;for(var handle in loadWaitHandleRegistry){if(!loadWaitHandleRegistry.hasOwnProperty(handle)){handleCount++;if(!loadWaitHandleRegistry[handle]){return}}}}
-clearInterval(loadWaitPoller);window.print();},10);return loadWaitPoller;}_pybloqs_load_sentinel_block_core = true;}
+clearInterval(loadWaitPoller);window.print();},10);return loadWaitPoller;}
+_pybloqs_load_sentinel_block_core = true;}
   </script>
   <style type="text/css">
    .pybloqs {

--- a/tests/regression/html_output/flow.html
+++ b/tests/regression/html_output/flow.html
@@ -106,10 +106,10 @@ if(i==-1){if(zip_eof)
 return 0;return-1;}
 n+=i;}
 return n;}
-var zip_inflate=function(str){var i,j;zip_inflate_start();zip_inflate_data=str;zip_inflate_pos=0;var buff=new Array(1024);var aout=[];while((i=zip_inflate_internal(buff,0,buff.length))>0){var cbuf=new Array(i);for(j=0;j<i;j++){cbuf[j]=String.fromCharCode(buff[j]);}
-aout[aout.length]=cbuf.join("");}
+var zip_inflate=function(str){var i,j;zip_inflate_start();zip_inflate_data=str;zip_inflate_pos=0;var buff=new Uint8Array(1024);var aout=[];var decoder=new TextDecoder("utf-8");while((i=zip_inflate_internal(buff,0,buff.length))>0){aout[aout.length]=decoder.decode(buff.slice(0,i));}
 zip_inflate_data=null;return aout.join("");}
 if(!window.RawDeflate)RawDeflate={};RawDeflate.inflate=zip_inflate;})();
+
 _pybloqs_load_sentinel_jsinflate = true;}
   </script>
   <script type="text/javascript">

--- a/tests/regression/html_output/grid.html
+++ b/tests/regression/html_output/grid.html
@@ -109,7 +109,8 @@ return n;}
 var zip_inflate=function(str){var i,j;zip_inflate_start();zip_inflate_data=str;zip_inflate_pos=0;var buff=new Array(1024);var aout=[];while((i=zip_inflate_internal(buff,0,buff.length))>0){var cbuf=new Array(i);for(j=0;j<i;j++){cbuf[j]=String.fromCharCode(buff[j]);}
 aout[aout.length]=cbuf.join("");}
 zip_inflate_data=null;return aout.join("");}
-if(!window.RawDeflate)RawDeflate={};RawDeflate.inflate=zip_inflate;})();_pybloqs_load_sentinel_jsinflate = true;}
+if(!window.RawDeflate)RawDeflate={};RawDeflate.inflate=zip_inflate;})();
+_pybloqs_load_sentinel_jsinflate = true;}
   </script>
   <script type="text/javascript">
    if(typeof(_pybloqs_load_sentinel_block_core) == 'undefined'){function isIE(){var myNav=navigator.userAgent.toLowerCase();return(myNav.indexOf('msie')!=-1)?parseInt(myNav.split('msie')[1]):false;}
@@ -119,7 +120,8 @@ function registerWaitHandle(handle){if(!window.loadWaitHandleRegistry){window.lo
 loadWaitHandleRegistry[handle]=false;}
 function setLoaded(handle){loadWaitHandleRegistry[handle]=true;}
 function runWaitPoller(){var loadWaitPoller=setInterval(function(){if("loadWaitHandleRegistry"in window){var handleCount=0;for(var handle in loadWaitHandleRegistry){if(!loadWaitHandleRegistry.hasOwnProperty(handle)){handleCount++;if(!loadWaitHandleRegistry[handle]){return}}}}
-clearInterval(loadWaitPoller);window.print();},10);return loadWaitPoller;}_pybloqs_load_sentinel_block_core = true;}
+clearInterval(loadWaitPoller);window.print();},10);return loadWaitPoller;}
+_pybloqs_load_sentinel_block_core = true;}
   </script>
   <style type="text/css">
    .pybloqs {

--- a/tests/regression/html_output/grid.html
+++ b/tests/regression/html_output/grid.html
@@ -106,10 +106,10 @@ if(i==-1){if(zip_eof)
 return 0;return-1;}
 n+=i;}
 return n;}
-var zip_inflate=function(str){var i,j;zip_inflate_start();zip_inflate_data=str;zip_inflate_pos=0;var buff=new Array(1024);var aout=[];while((i=zip_inflate_internal(buff,0,buff.length))>0){var cbuf=new Array(i);for(j=0;j<i;j++){cbuf[j]=String.fromCharCode(buff[j]);}
-aout[aout.length]=cbuf.join("");}
+var zip_inflate=function(str){var i,j;zip_inflate_start();zip_inflate_data=str;zip_inflate_pos=0;var buff=new Uint8Array(1024);var aout=[];var decoder=new TextDecoder("utf-8");while((i=zip_inflate_internal(buff,0,buff.length))>0){aout[aout.length]=decoder.decode(buff.slice(0,i));}
 zip_inflate_data=null;return aout.join("");}
 if(!window.RawDeflate)RawDeflate={};RawDeflate.inflate=zip_inflate;})();
+
 _pybloqs_load_sentinel_jsinflate = true;}
   </script>
   <script type="text/javascript">

--- a/tests/regression/html_output/hrule.html
+++ b/tests/regression/html_output/hrule.html
@@ -109,7 +109,8 @@ return n;}
 var zip_inflate=function(str){var i,j;zip_inflate_start();zip_inflate_data=str;zip_inflate_pos=0;var buff=new Array(1024);var aout=[];while((i=zip_inflate_internal(buff,0,buff.length))>0){var cbuf=new Array(i);for(j=0;j<i;j++){cbuf[j]=String.fromCharCode(buff[j]);}
 aout[aout.length]=cbuf.join("");}
 zip_inflate_data=null;return aout.join("");}
-if(!window.RawDeflate)RawDeflate={};RawDeflate.inflate=zip_inflate;})();_pybloqs_load_sentinel_jsinflate = true;}
+if(!window.RawDeflate)RawDeflate={};RawDeflate.inflate=zip_inflate;})();
+_pybloqs_load_sentinel_jsinflate = true;}
   </script>
   <script type="text/javascript">
    if(typeof(_pybloqs_load_sentinel_block_core) == 'undefined'){function isIE(){var myNav=navigator.userAgent.toLowerCase();return(myNav.indexOf('msie')!=-1)?parseInt(myNav.split('msie')[1]):false;}
@@ -119,7 +120,8 @@ function registerWaitHandle(handle){if(!window.loadWaitHandleRegistry){window.lo
 loadWaitHandleRegistry[handle]=false;}
 function setLoaded(handle){loadWaitHandleRegistry[handle]=true;}
 function runWaitPoller(){var loadWaitPoller=setInterval(function(){if("loadWaitHandleRegistry"in window){var handleCount=0;for(var handle in loadWaitHandleRegistry){if(!loadWaitHandleRegistry.hasOwnProperty(handle)){handleCount++;if(!loadWaitHandleRegistry[handle]){return}}}}
-clearInterval(loadWaitPoller);window.print();},10);return loadWaitPoller;}_pybloqs_load_sentinel_block_core = true;}
+clearInterval(loadWaitPoller);window.print();},10);return loadWaitPoller;}
+_pybloqs_load_sentinel_block_core = true;}
   </script>
   <style type="text/css">
    .pybloqs {

--- a/tests/regression/html_output/hrule.html
+++ b/tests/regression/html_output/hrule.html
@@ -106,10 +106,10 @@ if(i==-1){if(zip_eof)
 return 0;return-1;}
 n+=i;}
 return n;}
-var zip_inflate=function(str){var i,j;zip_inflate_start();zip_inflate_data=str;zip_inflate_pos=0;var buff=new Array(1024);var aout=[];while((i=zip_inflate_internal(buff,0,buff.length))>0){var cbuf=new Array(i);for(j=0;j<i;j++){cbuf[j]=String.fromCharCode(buff[j]);}
-aout[aout.length]=cbuf.join("");}
+var zip_inflate=function(str){var i,j;zip_inflate_start();zip_inflate_data=str;zip_inflate_pos=0;var buff=new Uint8Array(1024);var aout=[];var decoder=new TextDecoder("utf-8");while((i=zip_inflate_internal(buff,0,buff.length))>0){aout[aout.length]=decoder.decode(buff.slice(0,i));}
 zip_inflate_data=null;return aout.join("");}
 if(!window.RawDeflate)RawDeflate={};RawDeflate.inflate=zip_inflate;})();
+
 _pybloqs_load_sentinel_jsinflate = true;}
   </script>
   <script type="text/javascript">

--- a/tests/regression/html_output/hstack.html
+++ b/tests/regression/html_output/hstack.html
@@ -109,7 +109,8 @@ return n;}
 var zip_inflate=function(str){var i,j;zip_inflate_start();zip_inflate_data=str;zip_inflate_pos=0;var buff=new Array(1024);var aout=[];while((i=zip_inflate_internal(buff,0,buff.length))>0){var cbuf=new Array(i);for(j=0;j<i;j++){cbuf[j]=String.fromCharCode(buff[j]);}
 aout[aout.length]=cbuf.join("");}
 zip_inflate_data=null;return aout.join("");}
-if(!window.RawDeflate)RawDeflate={};RawDeflate.inflate=zip_inflate;})();_pybloqs_load_sentinel_jsinflate = true;}
+if(!window.RawDeflate)RawDeflate={};RawDeflate.inflate=zip_inflate;})();
+_pybloqs_load_sentinel_jsinflate = true;}
   </script>
   <script type="text/javascript">
    if(typeof(_pybloqs_load_sentinel_block_core) == 'undefined'){function isIE(){var myNav=navigator.userAgent.toLowerCase();return(myNav.indexOf('msie')!=-1)?parseInt(myNav.split('msie')[1]):false;}
@@ -119,7 +120,8 @@ function registerWaitHandle(handle){if(!window.loadWaitHandleRegistry){window.lo
 loadWaitHandleRegistry[handle]=false;}
 function setLoaded(handle){loadWaitHandleRegistry[handle]=true;}
 function runWaitPoller(){var loadWaitPoller=setInterval(function(){if("loadWaitHandleRegistry"in window){var handleCount=0;for(var handle in loadWaitHandleRegistry){if(!loadWaitHandleRegistry.hasOwnProperty(handle)){handleCount++;if(!loadWaitHandleRegistry[handle]){return}}}}
-clearInterval(loadWaitPoller);window.print();},10);return loadWaitPoller;}_pybloqs_load_sentinel_block_core = true;}
+clearInterval(loadWaitPoller);window.print();},10);return loadWaitPoller;}
+_pybloqs_load_sentinel_block_core = true;}
   </script>
   <style type="text/css">
    .pybloqs {

--- a/tests/regression/html_output/hstack.html
+++ b/tests/regression/html_output/hstack.html
@@ -106,10 +106,10 @@ if(i==-1){if(zip_eof)
 return 0;return-1;}
 n+=i;}
 return n;}
-var zip_inflate=function(str){var i,j;zip_inflate_start();zip_inflate_data=str;zip_inflate_pos=0;var buff=new Array(1024);var aout=[];while((i=zip_inflate_internal(buff,0,buff.length))>0){var cbuf=new Array(i);for(j=0;j<i;j++){cbuf[j]=String.fromCharCode(buff[j]);}
-aout[aout.length]=cbuf.join("");}
+var zip_inflate=function(str){var i,j;zip_inflate_start();zip_inflate_data=str;zip_inflate_pos=0;var buff=new Uint8Array(1024);var aout=[];var decoder=new TextDecoder("utf-8");while((i=zip_inflate_internal(buff,0,buff.length))>0){aout[aout.length]=decoder.decode(buff.slice(0,i));}
 zip_inflate_data=null;return aout.join("");}
 if(!window.RawDeflate)RawDeflate={};RawDeflate.inflate=zip_inflate;})();
+
 _pybloqs_load_sentinel_jsinflate = true;}
   </script>
   <script type="text/javascript">

--- a/tests/regression/html_output/markdown.html
+++ b/tests/regression/html_output/markdown.html
@@ -109,7 +109,8 @@ return n;}
 var zip_inflate=function(str){var i,j;zip_inflate_start();zip_inflate_data=str;zip_inflate_pos=0;var buff=new Array(1024);var aout=[];while((i=zip_inflate_internal(buff,0,buff.length))>0){var cbuf=new Array(i);for(j=0;j<i;j++){cbuf[j]=String.fromCharCode(buff[j]);}
 aout[aout.length]=cbuf.join("");}
 zip_inflate_data=null;return aout.join("");}
-if(!window.RawDeflate)RawDeflate={};RawDeflate.inflate=zip_inflate;})();_pybloqs_load_sentinel_jsinflate = true;}
+if(!window.RawDeflate)RawDeflate={};RawDeflate.inflate=zip_inflate;})();
+_pybloqs_load_sentinel_jsinflate = true;}
   </script>
   <script type="text/javascript">
    if(typeof(_pybloqs_load_sentinel_block_core) == 'undefined'){function isIE(){var myNav=navigator.userAgent.toLowerCase();return(myNav.indexOf('msie')!=-1)?parseInt(myNav.split('msie')[1]):false;}
@@ -119,7 +120,8 @@ function registerWaitHandle(handle){if(!window.loadWaitHandleRegistry){window.lo
 loadWaitHandleRegistry[handle]=false;}
 function setLoaded(handle){loadWaitHandleRegistry[handle]=true;}
 function runWaitPoller(){var loadWaitPoller=setInterval(function(){if("loadWaitHandleRegistry"in window){var handleCount=0;for(var handle in loadWaitHandleRegistry){if(!loadWaitHandleRegistry.hasOwnProperty(handle)){handleCount++;if(!loadWaitHandleRegistry[handle]){return}}}}
-clearInterval(loadWaitPoller);window.print();},10);return loadWaitPoller;}_pybloqs_load_sentinel_block_core = true;}
+clearInterval(loadWaitPoller);window.print();},10);return loadWaitPoller;}
+_pybloqs_load_sentinel_block_core = true;}
   </script>
   <style type="text/css">
    .pybloqs {

--- a/tests/regression/html_output/markdown.html
+++ b/tests/regression/html_output/markdown.html
@@ -106,10 +106,10 @@ if(i==-1){if(zip_eof)
 return 0;return-1;}
 n+=i;}
 return n;}
-var zip_inflate=function(str){var i,j;zip_inflate_start();zip_inflate_data=str;zip_inflate_pos=0;var buff=new Array(1024);var aout=[];while((i=zip_inflate_internal(buff,0,buff.length))>0){var cbuf=new Array(i);for(j=0;j<i;j++){cbuf[j]=String.fromCharCode(buff[j]);}
-aout[aout.length]=cbuf.join("");}
+var zip_inflate=function(str){var i,j;zip_inflate_start();zip_inflate_data=str;zip_inflate_pos=0;var buff=new Uint8Array(1024);var aout=[];var decoder=new TextDecoder("utf-8");while((i=zip_inflate_internal(buff,0,buff.length))>0){aout[aout.length]=decoder.decode(buff.slice(0,i));}
 zip_inflate_data=null;return aout.join("");}
 if(!window.RawDeflate)RawDeflate={};RawDeflate.inflate=zip_inflate;})();
+
 _pybloqs_load_sentinel_jsinflate = true;}
   </script>
   <script type="text/javascript">

--- a/tests/regression/html_output/nested.html
+++ b/tests/regression/html_output/nested.html
@@ -109,7 +109,8 @@ return n;}
 var zip_inflate=function(str){var i,j;zip_inflate_start();zip_inflate_data=str;zip_inflate_pos=0;var buff=new Array(1024);var aout=[];while((i=zip_inflate_internal(buff,0,buff.length))>0){var cbuf=new Array(i);for(j=0;j<i;j++){cbuf[j]=String.fromCharCode(buff[j]);}
 aout[aout.length]=cbuf.join("");}
 zip_inflate_data=null;return aout.join("");}
-if(!window.RawDeflate)RawDeflate={};RawDeflate.inflate=zip_inflate;})();_pybloqs_load_sentinel_jsinflate = true;}
+if(!window.RawDeflate)RawDeflate={};RawDeflate.inflate=zip_inflate;})();
+_pybloqs_load_sentinel_jsinflate = true;}
   </script>
   <script type="text/javascript">
    if(typeof(_pybloqs_load_sentinel_block_core) == 'undefined'){function isIE(){var myNav=navigator.userAgent.toLowerCase();return(myNav.indexOf('msie')!=-1)?parseInt(myNav.split('msie')[1]):false;}
@@ -119,7 +120,8 @@ function registerWaitHandle(handle){if(!window.loadWaitHandleRegistry){window.lo
 loadWaitHandleRegistry[handle]=false;}
 function setLoaded(handle){loadWaitHandleRegistry[handle]=true;}
 function runWaitPoller(){var loadWaitPoller=setInterval(function(){if("loadWaitHandleRegistry"in window){var handleCount=0;for(var handle in loadWaitHandleRegistry){if(!loadWaitHandleRegistry.hasOwnProperty(handle)){handleCount++;if(!loadWaitHandleRegistry[handle]){return}}}}
-clearInterval(loadWaitPoller);window.print();},10);return loadWaitPoller;}_pybloqs_load_sentinel_block_core = true;}
+clearInterval(loadWaitPoller);window.print();},10);return loadWaitPoller;}
+_pybloqs_load_sentinel_block_core = true;}
   </script>
   <style type="text/css">
    .pybloqs {

--- a/tests/regression/html_output/nested.html
+++ b/tests/regression/html_output/nested.html
@@ -106,10 +106,10 @@ if(i==-1){if(zip_eof)
 return 0;return-1;}
 n+=i;}
 return n;}
-var zip_inflate=function(str){var i,j;zip_inflate_start();zip_inflate_data=str;zip_inflate_pos=0;var buff=new Array(1024);var aout=[];while((i=zip_inflate_internal(buff,0,buff.length))>0){var cbuf=new Array(i);for(j=0;j<i;j++){cbuf[j]=String.fromCharCode(buff[j]);}
-aout[aout.length]=cbuf.join("");}
+var zip_inflate=function(str){var i,j;zip_inflate_start();zip_inflate_data=str;zip_inflate_pos=0;var buff=new Uint8Array(1024);var aout=[];var decoder=new TextDecoder("utf-8");while((i=zip_inflate_internal(buff,0,buff.length))>0){aout[aout.length]=decoder.decode(buff.slice(0,i));}
 zip_inflate_data=null;return aout.join("");}
 if(!window.RawDeflate)RawDeflate={};RawDeflate.inflate=zip_inflate;})();
+
 _pybloqs_load_sentinel_jsinflate = true;}
   </script>
   <script type="text/javascript">

--- a/tests/regression/html_output/pre.html
+++ b/tests/regression/html_output/pre.html
@@ -109,7 +109,8 @@ return n;}
 var zip_inflate=function(str){var i,j;zip_inflate_start();zip_inflate_data=str;zip_inflate_pos=0;var buff=new Array(1024);var aout=[];while((i=zip_inflate_internal(buff,0,buff.length))>0){var cbuf=new Array(i);for(j=0;j<i;j++){cbuf[j]=String.fromCharCode(buff[j]);}
 aout[aout.length]=cbuf.join("");}
 zip_inflate_data=null;return aout.join("");}
-if(!window.RawDeflate)RawDeflate={};RawDeflate.inflate=zip_inflate;})();_pybloqs_load_sentinel_jsinflate = true;}
+if(!window.RawDeflate)RawDeflate={};RawDeflate.inflate=zip_inflate;})();
+_pybloqs_load_sentinel_jsinflate = true;}
   </script>
   <script type="text/javascript">
    if(typeof(_pybloqs_load_sentinel_block_core) == 'undefined'){function isIE(){var myNav=navigator.userAgent.toLowerCase();return(myNav.indexOf('msie')!=-1)?parseInt(myNav.split('msie')[1]):false;}
@@ -119,7 +120,8 @@ function registerWaitHandle(handle){if(!window.loadWaitHandleRegistry){window.lo
 loadWaitHandleRegistry[handle]=false;}
 function setLoaded(handle){loadWaitHandleRegistry[handle]=true;}
 function runWaitPoller(){var loadWaitPoller=setInterval(function(){if("loadWaitHandleRegistry"in window){var handleCount=0;for(var handle in loadWaitHandleRegistry){if(!loadWaitHandleRegistry.hasOwnProperty(handle)){handleCount++;if(!loadWaitHandleRegistry[handle]){return}}}}
-clearInterval(loadWaitPoller);window.print();},10);return loadWaitPoller;}_pybloqs_load_sentinel_block_core = true;}
+clearInterval(loadWaitPoller);window.print();},10);return loadWaitPoller;}
+_pybloqs_load_sentinel_block_core = true;}
   </script>
   <style type="text/css">
    .pybloqs {

--- a/tests/regression/html_output/pre.html
+++ b/tests/regression/html_output/pre.html
@@ -106,10 +106,10 @@ if(i==-1){if(zip_eof)
 return 0;return-1;}
 n+=i;}
 return n;}
-var zip_inflate=function(str){var i,j;zip_inflate_start();zip_inflate_data=str;zip_inflate_pos=0;var buff=new Array(1024);var aout=[];while((i=zip_inflate_internal(buff,0,buff.length))>0){var cbuf=new Array(i);for(j=0;j<i;j++){cbuf[j]=String.fromCharCode(buff[j]);}
-aout[aout.length]=cbuf.join("");}
+var zip_inflate=function(str){var i,j;zip_inflate_start();zip_inflate_data=str;zip_inflate_pos=0;var buff=new Uint8Array(1024);var aout=[];var decoder=new TextDecoder("utf-8");while((i=zip_inflate_internal(buff,0,buff.length))>0){aout[aout.length]=decoder.decode(buff.slice(0,i));}
 zip_inflate_data=null;return aout.join("");}
 if(!window.RawDeflate)RawDeflate={};RawDeflate.inflate=zip_inflate;})();
+
 _pybloqs_load_sentinel_jsinflate = true;}
   </script>
   <script type="text/javascript">

--- a/tests/regression/html_output/raw.html
+++ b/tests/regression/html_output/raw.html
@@ -109,7 +109,8 @@ return n;}
 var zip_inflate=function(str){var i,j;zip_inflate_start();zip_inflate_data=str;zip_inflate_pos=0;var buff=new Array(1024);var aout=[];while((i=zip_inflate_internal(buff,0,buff.length))>0){var cbuf=new Array(i);for(j=0;j<i;j++){cbuf[j]=String.fromCharCode(buff[j]);}
 aout[aout.length]=cbuf.join("");}
 zip_inflate_data=null;return aout.join("");}
-if(!window.RawDeflate)RawDeflate={};RawDeflate.inflate=zip_inflate;})();_pybloqs_load_sentinel_jsinflate = true;}
+if(!window.RawDeflate)RawDeflate={};RawDeflate.inflate=zip_inflate;})();
+_pybloqs_load_sentinel_jsinflate = true;}
   </script>
   <script type="text/javascript">
    if(typeof(_pybloqs_load_sentinel_block_core) == 'undefined'){function isIE(){var myNav=navigator.userAgent.toLowerCase();return(myNav.indexOf('msie')!=-1)?parseInt(myNav.split('msie')[1]):false;}
@@ -119,7 +120,8 @@ function registerWaitHandle(handle){if(!window.loadWaitHandleRegistry){window.lo
 loadWaitHandleRegistry[handle]=false;}
 function setLoaded(handle){loadWaitHandleRegistry[handle]=true;}
 function runWaitPoller(){var loadWaitPoller=setInterval(function(){if("loadWaitHandleRegistry"in window){var handleCount=0;for(var handle in loadWaitHandleRegistry){if(!loadWaitHandleRegistry.hasOwnProperty(handle)){handleCount++;if(!loadWaitHandleRegistry[handle]){return}}}}
-clearInterval(loadWaitPoller);window.print();},10);return loadWaitPoller;}_pybloqs_load_sentinel_block_core = true;}
+clearInterval(loadWaitPoller);window.print();},10);return loadWaitPoller;}
+_pybloqs_load_sentinel_block_core = true;}
   </script>
   <style type="text/css">
    .pybloqs {

--- a/tests/regression/html_output/raw.html
+++ b/tests/regression/html_output/raw.html
@@ -106,10 +106,10 @@ if(i==-1){if(zip_eof)
 return 0;return-1;}
 n+=i;}
 return n;}
-var zip_inflate=function(str){var i,j;zip_inflate_start();zip_inflate_data=str;zip_inflate_pos=0;var buff=new Array(1024);var aout=[];while((i=zip_inflate_internal(buff,0,buff.length))>0){var cbuf=new Array(i);for(j=0;j<i;j++){cbuf[j]=String.fromCharCode(buff[j]);}
-aout[aout.length]=cbuf.join("");}
+var zip_inflate=function(str){var i,j;zip_inflate_start();zip_inflate_data=str;zip_inflate_pos=0;var buff=new Uint8Array(1024);var aout=[];var decoder=new TextDecoder("utf-8");while((i=zip_inflate_internal(buff,0,buff.length))>0){aout[aout.length]=decoder.decode(buff.slice(0,i));}
 zip_inflate_data=null;return aout.join("");}
 if(!window.RawDeflate)RawDeflate={};RawDeflate.inflate=zip_inflate;})();
+
 _pybloqs_load_sentinel_jsinflate = true;}
   </script>
   <script type="text/javascript">

--- a/tests/regression/html_output/span.html
+++ b/tests/regression/html_output/span.html
@@ -109,7 +109,8 @@ return n;}
 var zip_inflate=function(str){var i,j;zip_inflate_start();zip_inflate_data=str;zip_inflate_pos=0;var buff=new Array(1024);var aout=[];while((i=zip_inflate_internal(buff,0,buff.length))>0){var cbuf=new Array(i);for(j=0;j<i;j++){cbuf[j]=String.fromCharCode(buff[j]);}
 aout[aout.length]=cbuf.join("");}
 zip_inflate_data=null;return aout.join("");}
-if(!window.RawDeflate)RawDeflate={};RawDeflate.inflate=zip_inflate;})();_pybloqs_load_sentinel_jsinflate = true;}
+if(!window.RawDeflate)RawDeflate={};RawDeflate.inflate=zip_inflate;})();
+_pybloqs_load_sentinel_jsinflate = true;}
   </script>
   <script type="text/javascript">
    if(typeof(_pybloqs_load_sentinel_block_core) == 'undefined'){function isIE(){var myNav=navigator.userAgent.toLowerCase();return(myNav.indexOf('msie')!=-1)?parseInt(myNav.split('msie')[1]):false;}
@@ -119,7 +120,8 @@ function registerWaitHandle(handle){if(!window.loadWaitHandleRegistry){window.lo
 loadWaitHandleRegistry[handle]=false;}
 function setLoaded(handle){loadWaitHandleRegistry[handle]=true;}
 function runWaitPoller(){var loadWaitPoller=setInterval(function(){if("loadWaitHandleRegistry"in window){var handleCount=0;for(var handle in loadWaitHandleRegistry){if(!loadWaitHandleRegistry.hasOwnProperty(handle)){handleCount++;if(!loadWaitHandleRegistry[handle]){return}}}}
-clearInterval(loadWaitPoller);window.print();},10);return loadWaitPoller;}_pybloqs_load_sentinel_block_core = true;}
+clearInterval(loadWaitPoller);window.print();},10);return loadWaitPoller;}
+_pybloqs_load_sentinel_block_core = true;}
   </script>
   <style type="text/css">
    .pybloqs {

--- a/tests/regression/html_output/span.html
+++ b/tests/regression/html_output/span.html
@@ -106,10 +106,10 @@ if(i==-1){if(zip_eof)
 return 0;return-1;}
 n+=i;}
 return n;}
-var zip_inflate=function(str){var i,j;zip_inflate_start();zip_inflate_data=str;zip_inflate_pos=0;var buff=new Array(1024);var aout=[];while((i=zip_inflate_internal(buff,0,buff.length))>0){var cbuf=new Array(i);for(j=0;j<i;j++){cbuf[j]=String.fromCharCode(buff[j]);}
-aout[aout.length]=cbuf.join("");}
+var zip_inflate=function(str){var i,j;zip_inflate_start();zip_inflate_data=str;zip_inflate_pos=0;var buff=new Uint8Array(1024);var aout=[];var decoder=new TextDecoder("utf-8");while((i=zip_inflate_internal(buff,0,buff.length))>0){aout[aout.length]=decoder.decode(buff.slice(0,i));}
 zip_inflate_data=null;return aout.join("");}
 if(!window.RawDeflate)RawDeflate={};RawDeflate.inflate=zip_inflate;})();
+
 _pybloqs_load_sentinel_jsinflate = true;}
   </script>
   <script type="text/javascript">

--- a/tests/regression/html_output/title.html
+++ b/tests/regression/html_output/title.html
@@ -109,7 +109,8 @@ return n;}
 var zip_inflate=function(str){var i,j;zip_inflate_start();zip_inflate_data=str;zip_inflate_pos=0;var buff=new Array(1024);var aout=[];while((i=zip_inflate_internal(buff,0,buff.length))>0){var cbuf=new Array(i);for(j=0;j<i;j++){cbuf[j]=String.fromCharCode(buff[j]);}
 aout[aout.length]=cbuf.join("");}
 zip_inflate_data=null;return aout.join("");}
-if(!window.RawDeflate)RawDeflate={};RawDeflate.inflate=zip_inflate;})();_pybloqs_load_sentinel_jsinflate = true;}
+if(!window.RawDeflate)RawDeflate={};RawDeflate.inflate=zip_inflate;})();
+_pybloqs_load_sentinel_jsinflate = true;}
   </script>
   <script type="text/javascript">
    if(typeof(_pybloqs_load_sentinel_block_core) == 'undefined'){function isIE(){var myNav=navigator.userAgent.toLowerCase();return(myNav.indexOf('msie')!=-1)?parseInt(myNav.split('msie')[1]):false;}
@@ -119,7 +120,8 @@ function registerWaitHandle(handle){if(!window.loadWaitHandleRegistry){window.lo
 loadWaitHandleRegistry[handle]=false;}
 function setLoaded(handle){loadWaitHandleRegistry[handle]=true;}
 function runWaitPoller(){var loadWaitPoller=setInterval(function(){if("loadWaitHandleRegistry"in window){var handleCount=0;for(var handle in loadWaitHandleRegistry){if(!loadWaitHandleRegistry.hasOwnProperty(handle)){handleCount++;if(!loadWaitHandleRegistry[handle]){return}}}}
-clearInterval(loadWaitPoller);window.print();},10);return loadWaitPoller;}_pybloqs_load_sentinel_block_core = true;}
+clearInterval(loadWaitPoller);window.print();},10);return loadWaitPoller;}
+_pybloqs_load_sentinel_block_core = true;}
   </script>
   <style type="text/css">
    .pybloqs {

--- a/tests/regression/html_output/title.html
+++ b/tests/regression/html_output/title.html
@@ -106,10 +106,10 @@ if(i==-1){if(zip_eof)
 return 0;return-1;}
 n+=i;}
 return n;}
-var zip_inflate=function(str){var i,j;zip_inflate_start();zip_inflate_data=str;zip_inflate_pos=0;var buff=new Array(1024);var aout=[];while((i=zip_inflate_internal(buff,0,buff.length))>0){var cbuf=new Array(i);for(j=0;j<i;j++){cbuf[j]=String.fromCharCode(buff[j]);}
-aout[aout.length]=cbuf.join("");}
+var zip_inflate=function(str){var i,j;zip_inflate_start();zip_inflate_data=str;zip_inflate_pos=0;var buff=new Uint8Array(1024);var aout=[];var decoder=new TextDecoder("utf-8");while((i=zip_inflate_internal(buff,0,buff.length))>0){aout[aout.length]=decoder.decode(buff.slice(0,i));}
 zip_inflate_data=null;return aout.join("");}
 if(!window.RawDeflate)RawDeflate={};RawDeflate.inflate=zip_inflate;})();
+
 _pybloqs_load_sentinel_jsinflate = true;}
   </script>
   <script type="text/javascript">

--- a/tests/regression/html_output/title_levels.html
+++ b/tests/regression/html_output/title_levels.html
@@ -109,7 +109,8 @@ return n;}
 var zip_inflate=function(str){var i,j;zip_inflate_start();zip_inflate_data=str;zip_inflate_pos=0;var buff=new Array(1024);var aout=[];while((i=zip_inflate_internal(buff,0,buff.length))>0){var cbuf=new Array(i);for(j=0;j<i;j++){cbuf[j]=String.fromCharCode(buff[j]);}
 aout[aout.length]=cbuf.join("");}
 zip_inflate_data=null;return aout.join("");}
-if(!window.RawDeflate)RawDeflate={};RawDeflate.inflate=zip_inflate;})();_pybloqs_load_sentinel_jsinflate = true;}
+if(!window.RawDeflate)RawDeflate={};RawDeflate.inflate=zip_inflate;})();
+_pybloqs_load_sentinel_jsinflate = true;}
   </script>
   <script type="text/javascript">
    if(typeof(_pybloqs_load_sentinel_block_core) == 'undefined'){function isIE(){var myNav=navigator.userAgent.toLowerCase();return(myNav.indexOf('msie')!=-1)?parseInt(myNav.split('msie')[1]):false;}
@@ -119,7 +120,8 @@ function registerWaitHandle(handle){if(!window.loadWaitHandleRegistry){window.lo
 loadWaitHandleRegistry[handle]=false;}
 function setLoaded(handle){loadWaitHandleRegistry[handle]=true;}
 function runWaitPoller(){var loadWaitPoller=setInterval(function(){if("loadWaitHandleRegistry"in window){var handleCount=0;for(var handle in loadWaitHandleRegistry){if(!loadWaitHandleRegistry.hasOwnProperty(handle)){handleCount++;if(!loadWaitHandleRegistry[handle]){return}}}}
-clearInterval(loadWaitPoller);window.print();},10);return loadWaitPoller;}_pybloqs_load_sentinel_block_core = true;}
+clearInterval(loadWaitPoller);window.print();},10);return loadWaitPoller;}
+_pybloqs_load_sentinel_block_core = true;}
   </script>
   <style type="text/css">
    .pybloqs {

--- a/tests/regression/html_output/title_levels.html
+++ b/tests/regression/html_output/title_levels.html
@@ -106,10 +106,10 @@ if(i==-1){if(zip_eof)
 return 0;return-1;}
 n+=i;}
 return n;}
-var zip_inflate=function(str){var i,j;zip_inflate_start();zip_inflate_data=str;zip_inflate_pos=0;var buff=new Array(1024);var aout=[];while((i=zip_inflate_internal(buff,0,buff.length))>0){var cbuf=new Array(i);for(j=0;j<i;j++){cbuf[j]=String.fromCharCode(buff[j]);}
-aout[aout.length]=cbuf.join("");}
+var zip_inflate=function(str){var i,j;zip_inflate_start();zip_inflate_data=str;zip_inflate_pos=0;var buff=new Uint8Array(1024);var aout=[];var decoder=new TextDecoder("utf-8");while((i=zip_inflate_internal(buff,0,buff.length))>0){aout[aout.length]=decoder.decode(buff.slice(0,i));}
 zip_inflate_data=null;return aout.join("");}
 if(!window.RawDeflate)RawDeflate={};RawDeflate.inflate=zip_inflate;})();
+
 _pybloqs_load_sentinel_jsinflate = true;}
   </script>
   <script type="text/javascript">

--- a/tests/regression/html_output/vstack.html
+++ b/tests/regression/html_output/vstack.html
@@ -109,7 +109,8 @@ return n;}
 var zip_inflate=function(str){var i,j;zip_inflate_start();zip_inflate_data=str;zip_inflate_pos=0;var buff=new Array(1024);var aout=[];while((i=zip_inflate_internal(buff,0,buff.length))>0){var cbuf=new Array(i);for(j=0;j<i;j++){cbuf[j]=String.fromCharCode(buff[j]);}
 aout[aout.length]=cbuf.join("");}
 zip_inflate_data=null;return aout.join("");}
-if(!window.RawDeflate)RawDeflate={};RawDeflate.inflate=zip_inflate;})();_pybloqs_load_sentinel_jsinflate = true;}
+if(!window.RawDeflate)RawDeflate={};RawDeflate.inflate=zip_inflate;})();
+_pybloqs_load_sentinel_jsinflate = true;}
   </script>
   <script type="text/javascript">
    if(typeof(_pybloqs_load_sentinel_block_core) == 'undefined'){function isIE(){var myNav=navigator.userAgent.toLowerCase();return(myNav.indexOf('msie')!=-1)?parseInt(myNav.split('msie')[1]):false;}
@@ -119,7 +120,8 @@ function registerWaitHandle(handle){if(!window.loadWaitHandleRegistry){window.lo
 loadWaitHandleRegistry[handle]=false;}
 function setLoaded(handle){loadWaitHandleRegistry[handle]=true;}
 function runWaitPoller(){var loadWaitPoller=setInterval(function(){if("loadWaitHandleRegistry"in window){var handleCount=0;for(var handle in loadWaitHandleRegistry){if(!loadWaitHandleRegistry.hasOwnProperty(handle)){handleCount++;if(!loadWaitHandleRegistry[handle]){return}}}}
-clearInterval(loadWaitPoller);window.print();},10);return loadWaitPoller;}_pybloqs_load_sentinel_block_core = true;}
+clearInterval(loadWaitPoller);window.print();},10);return loadWaitPoller;}
+_pybloqs_load_sentinel_block_core = true;}
   </script>
   <style type="text/css">
    .pybloqs {

--- a/tests/regression/html_output/vstack.html
+++ b/tests/regression/html_output/vstack.html
@@ -106,10 +106,10 @@ if(i==-1){if(zip_eof)
 return 0;return-1;}
 n+=i;}
 return n;}
-var zip_inflate=function(str){var i,j;zip_inflate_start();zip_inflate_data=str;zip_inflate_pos=0;var buff=new Array(1024);var aout=[];while((i=zip_inflate_internal(buff,0,buff.length))>0){var cbuf=new Array(i);for(j=0;j<i;j++){cbuf[j]=String.fromCharCode(buff[j]);}
-aout[aout.length]=cbuf.join("");}
+var zip_inflate=function(str){var i,j;zip_inflate_start();zip_inflate_data=str;zip_inflate_pos=0;var buff=new Uint8Array(1024);var aout=[];var decoder=new TextDecoder("utf-8");while((i=zip_inflate_internal(buff,0,buff.length))>0){aout[aout.length]=decoder.decode(buff.slice(0,i));}
 zip_inflate_data=null;return aout.join("");}
 if(!window.RawDeflate)RawDeflate={};RawDeflate.inflate=zip_inflate;})();
+
 _pybloqs_load_sentinel_jsinflate = true;}
   </script>
   <script type="text/javascript">


### PR DESCRIPTION
The decompression code has bugs that will be difficult to fix with the version of JS supported by wkhtmltox. This prevents us from compressing the resources when saving the html to convert.

Once this is done we can then use `TextDecoder` to decode resources as utf-8 instead of utf-16 (the default for JavaScript) which fixes #136 . There is still a small bug that if a character lies on a 1024 byte boundary we truncate it, but this should be addressed by #137  