### PR TITLE
[ci] Add python 3.9 as a build target

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,6 +107,11 @@ jobs:
     docker:
       - image: cimg/python:3.8-browsers
     <<: *defaults
+  build_3_9:
+    working_directory: ~/manahl/PyBloqs_3_9
+    docker:
+      - image: cimg/python:3.9-browsers
+    <<: *defaults
   build_3_10:
     working_directory: ~/manahl/PyBloqs_3_10
     docker:
@@ -167,11 +172,13 @@ workflows:
   build_all:
     jobs:
       - build_3_8
+      - build_3_9
       - build_3_10
       - build_3_11
       - publish:
           requires:
             - build_3_8
+            - build_3_9
             - build_3_10
             - build_3_11
           filters:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 description = "Data Visualization and Report Building"
 name = "pybloqs"
-requires-python = ">= 3.6"
+requires-python = ">= 3.8"
 authors = [{ name = "Man Alpha Technology", email = "ManAlphaTech@man.com" }]
 keywords = ["ahl", "pdf", "html", "visualization", "report"]
 license = { file = "LICENSE" }


### PR DESCRIPTION
As we increase our testing coverage and move towards newer versions of python, dropping older versions, we want good coverage of the versions we do support. The package is marked as 3.6 onwards in the pyproject file so we test these.