### PR TITLE
[bugfix] Make ids globally unique and HTML-valid for the session

### DIFF
--- a/pybloqs/html.py
+++ b/pybloqs/html.py
@@ -118,18 +118,21 @@ def id_generator_uuid() -> Generator[str, None, None]:
     Generates unique identifiers using the `uuid` package.
     """
     while True:
-        yield str(uuid.uuid4()).replace("-", "")
+        yield "uuid4" + str(uuid.uuid4()).replace("-", "")
+
+
+_id_generator_sequential_counter: int = 0
 
 
 def id_generator_sequential() -> Generator[str, None, None]:
     """
     Generatres unique identifiers sequentially from a known constant seed.
     """
-    counter = 0
+    global _id_generator_sequential_counter
 
     while True:
-        yield PYBLOQS_ID_PREFIX + str(counter)
-        counter += 1
+        yield PYBLOQS_ID_PREFIX + str(_id_generator_sequential_counter)
+        _id_generator_sequential_counter += 1
 
 
 def id_generator() -> Iterator[str]:

--- a/tests/unit/test_html.py
+++ b/tests/unit/test_html.py
@@ -54,6 +54,7 @@ def test_css_elem():
 
 
 def test_id_generator_sequential():
+    h._id_generator_sequential_counter = 0
     id_gen = h.id_generator_sequential()
 
     first_id = next(id_gen)


### PR DESCRIPTION
If you render multiple blocks, IDs of the components may overlap. We keep state between invocations to id_generator_sequential in order to prevent this.

Additionally HTML ids must start with a letter for HTML4 (which our blocks render as) so we add a prefix to the uuid string.