### PR TITLE
[bugfix] Render resources in iPython cells

### DIFF
--- a/pybloqs/block/base.py
+++ b/pybloqs/block/base.py
@@ -477,7 +477,10 @@ class BaseBlock:
         :return: Data to be displayed
         """
         container = root("div")
-        self._write_block(container, Cfg(), id_generator())
+        resource_deps = DependencyTracker(default_css_main)
+        self._write_block(container, Cfg(), id_generator(), resource_deps=resource_deps)
+        for resource in resource_deps:
+            resource.write(container, permit_compression=False)
 
         # Write children into the output
         output = BytesIO()

--- a/tests/unit/block/test_base_unit.py
+++ b/tests/unit/block/test_base_unit.py
@@ -5,6 +5,7 @@ import pytest
 
 import pybloqs.block.base as bbase
 import pybloqs.config as config
+import pybloqs.static as static
 
 
 def test_publish_block():
@@ -86,3 +87,10 @@ def test_save_filename_and_extension(filename, fmt, exp_name, exp_fmt, exp_outpu
         assert result == exp_name
     if exp_fmt is not None:
         assert result.split(".")[-1] == exp_fmt
+
+
+def test_write_html_resources():
+    with patch.object(bbase.BaseBlock, "_write_contents"):
+        b = bbase.BaseBlock()
+        b.resource_deps = (static.Css(css_string="*{color:limegreen;}", name="dummy"),)
+        assert "limegreen" in b._repr_html_()


### PR DESCRIPTION
We were not rendering resources (CSS and JS) for blocks in iPython or Jupyter cells. This renders them as part of the block.