### PR TITLE
[bugfix] Remove dummy code

### DIFF
--- a/pybloqs/email.py
+++ b/pybloqs/email.py
@@ -156,7 +156,6 @@ def send_html_report(
     """
     # create the dom for querying/modifying the html document
     parser = html5lib.HTMLParser(tree=treebuilders.getTreeBuilder("dom"))
-    html_str = "<a>foo</a>"
     dom = parser.parse(html_str)
 
     if not subject:


### PR DESCRIPTION
A testing line that just replaced the contents of all emails with a line reading "foo" was accidentally introduced during a large refactor. This removes it.