### PR TITLE
Don't use async compression stream

### DIFF
--- a/pybloqs/static/jsinflate.js
+++ b/pybloqs/static/jsinflate.js
@@ -1,3 +1,5 @@
-(function(){var zip_inflate=async function(str){const binaryString=atob(str);var bytes=new Uint8Array(binaryString.length);for(var i=0;i<binaryString.length;i++){bytes[i]=binaryString.charCodeAt(i);}
-return await new Response(new Blob([bytes]).stream().pipeThrough(new DecompressionStream('deflate'))).text();}
+(function(){function decompress(bytes){const input=new ReadableStream({start(c){c.enqueue(bytes);c.close();},}).pipeThrough(new DecompressionStream("deflate"));const reader=input.getReader();const chunks=[];return reader.read().then(function process({done,value}){if(done){const decompressedData=new Uint8Array(chunks.reduce((acc,chunk)=>acc+chunk.length,0));let offset=0;chunks.forEach(chunk=>{decompressedData.set(chunk,offset);offset+=chunk.length;});return decompressedData;}
+chunks.push(value);return reader.read().then(process);});}
+var zip_inflate=async function(str){const binaryString=atob(str);var bytes=new Uint8Array(binaryString.length);for(var i=0;i<binaryString.length;i++){bytes[i]=binaryString.charCodeAt(i);}
+return decompress(bytes).then(decompressed=>(new TextDecoder().decode(decompressed))).catch(console.error);}
 if(!window.RawDeflate)RawDeflate={};RawDeflate.inflate=zip_inflate;})();

--- a/pybloqs/static/uncompressed/jsinflate.js
+++ b/pybloqs/static/uncompressed/jsinflate.js
@@ -1,15 +1,41 @@
 (function(){
+  function decompress(bytes) {
+  const input = new ReadableStream({
+    start(c) {
+      c.enqueue(bytes);
+      c.close();
+    },
+  }).pipeThrough(new DecompressionStream("deflate"));
+
+  const reader = input.getReader();
+  const chunks = [];
+
+  return reader.read().then(function process({ done, value }) {
+    if (done) {
+      const decompressedData = new Uint8Array(
+        chunks.reduce((acc, chunk) => acc + chunk.length, 0)
+      );
+      let offset = 0;
+      chunks.forEach(chunk => {
+        decompressedData.set(chunk, offset);
+        offset += chunk.length;
+      });
+      return decompressedData;
+    }
+    chunks.push(value);
+    return reader.read().then(process);
+  });
+}
+
 var zip_inflate=async function(str){
   const binaryString = atob(str);
   var bytes = new Uint8Array(binaryString.length);
   for (var i = 0; i < binaryString.length; i++) {
       bytes[i] = binaryString.charCodeAt(i);
   }
-  return await new Response(
-    new Blob([bytes])
-      .stream()
-      .pipeThrough(new DecompressionStream('deflate'))
-  ).text();
+  return decompress(bytes)
+    .then(decompressed => (new TextDecoder().decode(decompressed)))
+    .catch(console.error);
 }
 if(!window.RawDeflate)RawDeflate={};RawDeflate.inflate=zip_inflate;}
 )();


### PR DESCRIPTION
We were using `await` on the compression stream but this meant that somtimes the rest of the HTML document was being loaded before the resources had been inflated.

Now, we decompress in a blocking manner by manually pumping the promise so that we eliminate all the async.

This should fix #153 