### PR TITLE
fix yaml.load error

### DIFF
--- a/pybloqs/config.py
+++ b/pybloqs/config.py
@@ -16,10 +16,15 @@ user_config = {
     "id_precision": 10,  # Number of digits to use from the id hash
 }
 
-try:
-    with open(os.path.expanduser("~/.pybloqs.cfg")) as config_file:
-        stored_config = yaml.load(config_file)
-        if stored_config is not None:
-            user_config.update(stored_config)
-except OSError:
-    pass
+
+def _load_overrides() -> None:
+    try:
+        with open(os.path.expanduser("~/.pybloqs.cfg")) as config_file:
+            stored_config = yaml.safe_load(config_file)
+            if stored_config is not None:
+                user_config.update(stored_config)
+    except OSError:
+        pass
+
+
+_load_overrides()

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,11 @@
+from tempfile import NamedTemporaryFile
+from unittest.mock import patch
+from pybloqs import config
+
+
+def test_yaml_load_config():
+    with NamedTemporaryFile() as f, patch("pybloqs.config.os.path.expanduser", return_value=f.name):
+        f.write(b"public_dir: '/abc'")
+        f.flush()
+        config._load_overrides()
+        assert config.user_config["public_dir"] == "/abc"


### PR DESCRIPTION
fix yaml.load() errors
TypeError: load() missing 1 required positional argument: 'Loader' HINT: you should use yaml.safe_load() instead of yaml.load() to read yaml files. .
in pyyaml 3+: yaml.load(file) takes one argument
in pyyaml 5+: yaml.load(file, loader=LoaderClass) requires an extra argument to specify a loader. the yaml library could save and load raw python object out-of-the-box, which is insecure, so it stopped supporting that out-of-the-box. .
to read yaml files, you should use yaml.safe_load() instead.