### PR TITLE
[server] Permit specifying the endpoint that blocks serve on

### DIFF
--- a/docs/source/server/index.md
+++ b/docs/source/server/index.md
@@ -376,6 +376,15 @@ HTMX aims to provide, among [other things](https://htmx.org/essays/hateoas/), a 
 
 The `@bloqs_provider` decorator wraps a function that generates a PyBloq in a new block type called a `BloqsProvider`. This block presents the `get_fragment` function which just returns the HTML content of the block, similarly to `BaseBlock._write_block`. The decorator then registers this function with the server at an endpoint given by the `id` of the block provider.
 
+:::{admonition} Setting the endpoint
+You can change the ID (and hence the URL that the block serves) by passing parameters to the decorator. In fact these are all forwarded to the constructor of the `BloqsProvider` object.
+```python
+@bloqs_provider(id_="some_name")  # serves on /some_name
+def some_provider() -> BaseBlock:
+    ...
+```
+:::
+
 `BloqsProvider`s also present as a `BaseBlock` themselves, but the content they render is (very similar to)
 ```html
 <div hx-trigger="revealed" hx-get="/{ID OF BLOQS PROVIDER}">

--- a/docs/source/server_demo.py
+++ b/docs/source/server_demo.py
@@ -74,8 +74,8 @@ chebyshev_dataframe = pd.DataFrame(
 chebyshev_dataframe.index.name = "x"
 for i in range(2, 6):
     chebyshev_dataframe[f"T{i}"] = (
-        2 * chebyshev_dataframe[f"T{i-1}"] * chebyshev_dataframe["T1"]
-        - chebyshev_dataframe[f"T{i-2}"]
+        2 * chebyshev_dataframe[f"T{i - 1}"] * chebyshev_dataframe["T1"]
+        - chebyshev_dataframe[f"T{i - 2}"]
     )
 
 # simple_block
@@ -158,7 +158,7 @@ pybloqs.server.serve_block(very_tall, "/very_tall")
 
 
 # greet
-@bloqs_provider
+@bloqs_provider(id_="greet_block")
 def greet(
     name: str,
 ) -> pybloqs.BaseBlock:

--- a/pybloqs/block/base.py
+++ b/pybloqs/block/base.py
@@ -37,6 +37,7 @@ class BaseBlock:
         styles=None,
         classes: Union[str, Iterable[str]] = (),
         anchor=None,
+        id_: Optional[str] = None,
         **kwargs,
     ) -> None:
         self._settings = Cfg(
@@ -52,7 +53,7 @@ class BaseBlock:
         )
         # Anchor should not be inherited, so keep outside of Cfg
         self._anchor = anchor
-        self._id = uuid.uuid4().hex
+        self._id = id_ or uuid.uuid4().hex
 
     def render_html(
         self,

--- a/tests/unit/server/test_decorator.py
+++ b/tests/unit/server/test_decorator.py
@@ -1,0 +1,27 @@
+from pybloqs.server import bloqs_provider
+from pybloqs.server.provider import BloqsProvider
+
+
+def test_provider_decorator_no_params():
+    @bloqs_provider
+    def dummy():
+        return "Foo"
+
+    assert isinstance(dummy, BloqsProvider)
+
+
+def test_provider_decorator_with_params():
+    @bloqs_provider(id_="id")
+    def dummy():
+        return "Foo"
+
+    assert isinstance(dummy, BloqsProvider)
+    assert dummy._id == "id"
+
+
+def test_provider_decorator_with_no_params():
+    @bloqs_provider()
+    def dummy():
+        return "Foo"
+
+    assert isinstance(dummy, BloqsProvider)


### PR DESCRIPTION
By passing construction parameters to the BloqsProvider through the decorator bloqs_provider, we can set the _id variable and thus the endpoint that the server serves each bloq on.

We make the decorator accept optional parameters so that you can call it "bare" or with parameters, keeping backwards compatibility with previous bare-only usage.