### PR TITLE
Bugfix small errors in HTMX shims

### DIFF
--- a/pybloqs/server/static/htmx.min.js
+++ b/pybloqs/server/static/htmx.min.js
@@ -828,7 +828,7 @@ var htmx = (function() {
    */
   function normalizePath(path) {
     try {
-      if (url.location.href == 'about:srcdoc') {
+      if (document.location.href == 'about:srcdoc') {
         path = 'http://localhost' + path;
       }
       const url = new URL(path)
@@ -3872,7 +3872,7 @@ var htmx = (function() {
     if (xhr.responseURL && typeof (URL) !== 'undefined') {
       try {
         let path;
-        if (url.location.href == 'srcDoc') {
+        if (document.location.href == 'srcDoc') {
           path = 'localhost' + xhr.responseURL;
         } else {
           path = xhr.responseURL;


### PR DESCRIPTION
We had referred to `url.location.href` which was not defined yet in that block. We should have been looking at the location of the page via document.location.href.