### PR TITLE
Replace inner html

### DIFF
--- a/pybloqs/server/provider.py
+++ b/pybloqs/server/provider.py
@@ -123,7 +123,9 @@ class BloqsProvider(pybloqs.BaseBlock):
             if resource_deps is not None:
                 for res in self.resource_deps:
                     resource_deps.add(res)
-            div_to_replace = append_to(parent, "div", **{"hx-trigger": "revealed", "hx-swap": "outerHTML", "hx-get": self.url})
+            div_to_replace = append_to(
+                parent, "div", **{"hx-trigger": "revealed", "hx-swap": "outerHTML", "hx-get": self.url}
+            )
             if self.loading_block:
                 self.loading_block._write_block(
                     div_to_replace, parent_cfg, id_gen, resource_deps=resource_deps, static_output=static_output

--- a/pybloqs/server/provider.py
+++ b/pybloqs/server/provider.py
@@ -123,7 +123,7 @@ class BloqsProvider(pybloqs.BaseBlock):
             if resource_deps is not None:
                 for res in self.resource_deps:
                     resource_deps.add(res)
-            div_to_replace = append_to(parent, "div", **{"hx-trigger": "revealed", "hx-get": self.url})
+            div_to_replace = append_to(parent, "div", **{"hx-trigger": "revealed", "hx-swap": "outerHTML", "hx-get": self.url})
             if self.loading_block:
                 self.loading_block._write_block(
                     div_to_replace, parent_cfg, id_gen, resource_deps=resource_deps, static_output=static_output


### PR DESCRIPTION
We were seeing an issue where nesting multiple `Tab` blocks inside each other would cause a refresh of a parent element. By replacing the parent div using `outerHTML` this is resolved.