### PR TITLE
fix warning in pandas 2.1: DataFrame.applymap has been deprecated. Us…

### DIFF
--- a/pybloqs/block/table_formatters.py
+++ b/pybloqs/block/table_formatters.py
@@ -715,7 +715,7 @@ class FmtHeatmap(TableFormatter):
             selection = df.loc[rows, columns]
 
         # Replace strings with nan as they otherwise confuse min() and max()
-        if hasattr(selection, "map")
+        if hasattr(selection, "map"):
             # pandas 2.1 warning: DataFrame.applymap has been deprecated. Use DataFrame.map instead.
             selection = selection.map(lambda x: np.nan if not isinstance(x, numbers.Number) else x)
         else:

--- a/pybloqs/block/table_formatters.py
+++ b/pybloqs/block/table_formatters.py
@@ -715,7 +715,11 @@ class FmtHeatmap(TableFormatter):
             selection = df.loc[rows, columns]
 
         # Replace strings with nan as they otherwise confuse min() and max()
-        selection = selection.applymap(lambda x: np.nan if not isinstance(x, numbers.Number) else x)
+        if hasattr(selection, "map")
+            # pandas 2.1 warning: DataFrame.applymap has been deprecated. Use DataFrame.map instead.
+            selection = selection.map(lambda x: np.nan if not isinstance(x, numbers.Number) else x)
+        else:
+            selection = selection.applymap(lambda x: np.nan if not isinstance(x, numbers.Number) else x)
 
         return selection
 


### PR DESCRIPTION
simple fix for pandas warnings.

I am investigating some failing job and the logs have hundreds of this warning. we should fix the warning.

the warning and the new function `.map()` were introduced in pandas 2.1.  We have to if/else to have broad pandas support without raising warnings.
https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.applymap.html

```
/users/isys/svc-cpm/pyenvs/2025-08-26_17_45_01/lib/python3.11/site-packages/pybloqs/block/table_formatters.py:718: FutureWarning:
DataFrame.applymap has been deprecated. Use DataFrame.map instead.
```